### PR TITLE
Fix #40: prevent crash on partial altimeter input; preserve null positions in URL state

### DIFF
--- a/src/components/AircraftPerformance.tsx
+++ b/src/components/AircraftPerformance.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { WorksheetData } from "@/utils/types";
 import { isApiPopulatedData } from "@/utils/weatherDataMapper";
 
@@ -42,6 +42,24 @@ export default function AircraftPerformance({
     ...initialData,
   }));
 
+  const [altimeterStrings, setAltimeterStrings] = useState<
+    [string, string, string]
+  >([
+    initialData.altimeter[0]?.toString() ?? "",
+    initialData.altimeter[1]?.toString() ?? "",
+    initialData.altimeter[2]?.toString() ?? "",
+  ]);
+
+  // Track the last altimeter values we ourselves pushed upstream via onUpdate.
+  // Used to distinguish our own round-trips from genuine external changes (e.g. API).
+  const lastPushedAltimeterRef = useRef<
+    [number | null, number | null, number | null]
+  >([
+    initialData.altimeter[0] ?? null,
+    initialData.altimeter[1] ?? null,
+    initialData.altimeter[2] ?? null,
+  ]);
+
   // Determine which fields are API-populated
   const apiPopulated = worksheetData
     ? isApiPopulatedData(worksheetData)
@@ -60,6 +78,9 @@ export default function AircraftPerformance({
         ...prev,
         ...initialData,
       }));
+      // NOTE: Do NOT sync altimeterStrings here — this effect fires on every
+      // keystroke (because onUpdate → parent state change → initialData change)
+      // and would clear the field while the user is mid-entry.
     }
   }, [initialData]);
 
@@ -74,6 +95,27 @@ export default function AircraftPerformance({
         altitude: worksheetData.altitude ?? prev.altitude,
         rwy: worksheetData.rwy ?? prev.rwy,
       }));
+      // Only sync altimeter display strings when the incoming values differ from
+      // what we last pushed upstream. This prevents the keystroke round-trip
+      // (user types → onUpdate → state changes → worksheetData changes → this
+      // effect fires) from resetting the field while the user is mid-entry.
+      if (worksheetData.altimeter) {
+        const incoming = worksheetData.altimeter;
+        const lastPushed = lastPushedAltimeterRef.current;
+        const isExternalChange = incoming.some((v, i) => v !== lastPushed[i]);
+        if (isExternalChange) {
+          setAltimeterStrings([
+            incoming[0]?.toString() ?? "",
+            incoming[1]?.toString() ?? "",
+            incoming[2]?.toString() ?? "",
+          ]);
+          lastPushedAltimeterRef.current = [...incoming] as [
+            number | null,
+            number | null,
+            number | null
+          ];
+        }
+      }
     }
   }, [worksheetData]);
 
@@ -175,6 +217,31 @@ export default function AircraftPerformance({
     onUpdate(newData);
   };
 
+  const handleAltimeterChange = (index: number, value: string) => {
+    const newStrings = [...altimeterStrings] as [string, string, string];
+    newStrings[index] = value;
+    setAltimeterStrings(newStrings);
+
+    const num = value === "" ? null : Number(value);
+    const isValid = num === null || (num >= 28.0 && num <= 31.0);
+    const altimeterArray = [...initialData.altimeter] as [
+      number | null,
+      number | null,
+      number | null
+    ];
+    altimeterArray[index] = isValid ? num : null;
+
+    // Record what we're pushing so the worksheetData useEffect can ignore
+    // this round-trip and not reset the display strings mid-entry.
+    lastPushedAltimeterRef.current = [...altimeterArray] as [
+      number | null,
+      number | null,
+      number | null
+    ];
+
+    onUpdate({ ...initialData, altimeter: altimeterArray });
+  };
+
   return (
     <div className="w-full max-w-4xl">
       <h2 className="text-xl font-bold mb-4">Aircraft Performance</h2>
@@ -255,10 +322,8 @@ export default function AircraftPerformance({
                   step="0.01"
                   min="28.00"
                   max="31.00"
-                  value={getValue("altimeter", 0)}
-                  onChange={(e) =>
-                    handleInputChange("altimeter", 0, e.target.value)
-                  }
+                  value={altimeterStrings[0]}
+                  onChange={(e) => handleAltimeterChange(0, e.target.value)}
                   className={getInputStyling("altimeter", 0)}
                 />
               </td>
@@ -267,11 +332,9 @@ export default function AircraftPerformance({
                   type="number"
                   step="0.01"
                   min="28.00"
-                  max="31.99"
-                  value={getValue("altimeter", 1)}
-                  onChange={(e) =>
-                    handleInputChange("altimeter", 1, e.target.value)
-                  }
+                  max="31.00"
+                  value={altimeterStrings[1]}
+                  onChange={(e) => handleAltimeterChange(1, e.target.value)}
                   className={getInputStyling("altimeter", 1)}
                 />
               </td>
@@ -280,11 +343,9 @@ export default function AircraftPerformance({
                   type="number"
                   step="0.01"
                   min="28.00"
-                  max="31.99"
-                  value={getValue("altimeter", 2)}
-                  onChange={(e) =>
-                    handleInputChange("altimeter", 2, e.target.value)
-                  }
+                  max="31.00"
+                  value={altimeterStrings[2]}
+                  onChange={(e) => handleAltimeterChange(2, e.target.value)}
                   className={getInputStyling("altimeter", 2)}
                 />
               </td>

--- a/src/components/ClimbPerformance.tsx
+++ b/src/components/ClimbPerformance.tsx
@@ -54,18 +54,22 @@ export default function ClimbPerformance({
       if (aircraft) {
         const climbPerformance: FlexibleInterpolationTable =
           aircraft.climbPerformance;
-        setRatesOfClimb(
-          PAs.map((pa, idx) =>
-            Math.round(
-              bilinearInterpolateFlexible(
-                climbPerformance,
-                pa as number,
-                OATs[idx] as number,
-                options
+        try {
+          setRatesOfClimb(
+            PAs.map((pa, idx) =>
+              Math.round(
+                bilinearInterpolateFlexible(
+                  climbPerformance,
+                  pa as number,
+                  OATs[idx] as number,
+                  options
+                )
               )
-            )
-          ) as [number, number, number]
-        );
+            ) as [number, number, number]
+          );
+        } catch {
+          setRatesOfClimb([0, 0, 0]);
+        }
       }
     }
   }, [OATs, PAs, aircraftModel]);

--- a/src/utils/__tests__/urlState.test.ts
+++ b/src/utils/__tests__/urlState.test.ts
@@ -38,7 +38,24 @@ describe("serializeState", () => {
     expect(params.get("strings")).toBe("a,b,c");
     expect(params.get("mixed")).toBe("1,b,3");
     expect(params.has("empty")).toBe(false);
-    expect(params.get("withEmpty")).toBe("1,2,3");
+    // Null/empty positions are preserved as "" to maintain index positions
+    expect(params.get("withEmpty")).toBe("1,,,2,,3");
+  });
+
+  it("should preserve null positions in arrays for correct round-tripping", () => {
+    // Regression test for issue #40: altimeter=[30.24, null, 30.31] must not
+    // collapse to [30.24, 30.31] which would shift arrival into operating position.
+    const state = {
+      altimeter: [30.24, null, 30.31],
+      temp: [null, 5, null],
+      altitude: [5344, null, 4472],
+    };
+
+    const queryString = serializeState(state);
+    const params = new URLSearchParams(queryString);
+    expect(params.get("altimeter")).toBe("30.24,,30.31");
+    expect(params.get("temp")).toBe(",5,");
+    expect(params.get("altitude")).toBe("5344,,4472");
   });
 
   it("should serialize nested arrays correctly", () => {
@@ -184,5 +201,44 @@ describe("deserializeState", () => {
       ],
       turb: true,
     });
+  });
+
+  it("should restore null positions from empty slots in arrays", () => {
+    // Regression test for issue #40: "30.24,,30.31" must restore to
+    // [30.24, null, 30.31], not [30.24, 30.31] with arrival shifted to operating.
+    const params = new URLSearchParams();
+    params.set("altimeter", "30.24,,30.31");
+    params.set("temp", ",5,");
+    params.set("altitude", "5344,,4472");
+
+    const initialState = {
+      altimeter: [null, null, null] as (number | null)[],
+      temp: [null, null, null] as (number | null)[],
+      altitude: [null, null, null] as (number | null)[],
+    };
+
+    const result = deserializeState(params, initialState);
+    expect(result.altimeter).toEqual([30.24, null, 30.31]);
+    expect(result.temp).toEqual([null, 5, null]);
+    expect(result.altitude).toEqual([5344, null, 4472]);
+  });
+
+  it("should round-trip arrays with null positions correctly", () => {
+    // End-to-end: serialize then deserialize preserves null positions at correct indices.
+    const originalState = {
+      altimeter: [30.24, null, 30.31] as (number | null)[],
+      temp: [null, 5, -2] as (number | null)[],
+    };
+
+    const serialized = serializeState(originalState as Record<string, unknown>);
+
+    const initialState = {
+      altimeter: [null, null, null] as (number | null)[],
+      temp: [null, null, null] as (number | null)[],
+    };
+
+    const restored = deserializeState(serialized, initialState);
+    expect(restored.altimeter).toEqual([30.24, null, 30.31]);
+    expect(restored.temp).toEqual([null, 5, -2]);
   });
 });

--- a/src/utils/urlState.ts
+++ b/src/utils/urlState.ts
@@ -22,18 +22,22 @@ const spaceEncoder = (
 // Filter function for qs.stringify to skip null, undefined, empty strings, and empty arrays
 const filterEmpty = (prefix: string, value: unknown): unknown => {
   if (value === null || value === undefined || value === "") {
-    return undefined; // Skip these values
+    return undefined; // Skip top-level null/empty values
   }
   if (Array.isArray(value)) {
     // For nested arrays (2D), we'll handle them in preprocessing
     if (value.length > 0 && Array.isArray(value[0])) {
       return value; // Keep nested arrays for special handling
     }
-    // For simple arrays, filter out empty values and skip if empty
-    const filtered = value.filter(
-      (v) => v !== null && v !== undefined && v !== ""
+    // For simple arrays, preserve null/empty positions as "" so they appear as
+    // ",," in the URL (e.g. [30.24, null, 30.31] → "30.24,,30.31").
+    // This preserves index positions during round-trips (deserialization maps
+    // "" back to null). Skip the entire array only if all values are empty.
+    const mapped = value.map((v) =>
+      v === null || v === undefined || v === "" ? "" : v
     );
-    return filtered.length > 0 ? filtered : undefined;
+    const hasAnyValue = mapped.some((v) => v !== "");
+    return hasAnyValue ? mapped : undefined;
   }
   return value;
 };
@@ -104,7 +108,11 @@ const convertValue = (value: unknown, hint: unknown): unknown => {
       const vStr = String(v);
       const typeHint =
         (hint as unknown[])[i] ?? (hint as unknown[]).find((h) => h !== null && h !== undefined);
-      
+
+      // Empty string is a preserved null position (from serialization of null array
+      // elements as "" to maintain index positions). Restore to null.
+      if (vStr === "") return null;
+
       if (typeof typeHint === "string") return vStr;
       if (typeof typeHint === "boolean") return vStr === "1" || vStr === "true";
       if (


### PR DESCRIPTION
## Summary

Fixes #40 — client-side crash when the app receives an out-of-range pressure altitude due to partial altimeter input.

- **Root cause:** Typing a partial altimeter value (e.g. `3` while intending `30.27`) immediately pushed `altimeter=3` to state, causing `altitudeToPressureAltitude` to compute ~39,420 ft PA. At that altitude, C206 climb performance data has `null` corner values, causing `bilinearInterpolateFlexible` to throw and crash the page.
- **Altimeter validation:** Altimeter inputs now use local string state for display, only propagating values upstream when they fall within the valid range (28.00–31.00 inHg). Partial/invalid values cause calculations to show no result rather than crashing. A `lastPushedAltimeterRef` prevents keystroke round-trips from clearing the field mid-entry.
- **Safety net:** `bilinearInterpolateFlexible` in `ClimbPerformance` is now wrapped in `try/catch` — shows 0 instead of crashing if any invalid PA reaches interpolation.
- **URL state bug fix:** Null positions in arrays were being stripped during serialization (`[30.24, null, 30.31]` → `30.24,30.31`), causing the arrival altimeter value to shift into the operating slot on page reload. Fixed by preserving null positions as empty slots (`30.24,,30.31`) and restoring them to `null` on deserialize.

## Test plan

- [x] All 287 existing + new tests pass (`npm test`)
- [x] Type `3` into an altimeter field — field shows `3`, calculations show `"-"`, page does not crash
- [x] Complete the value to `30.27` — calculations resume correctly
- [x] Set departure altimeter, leave operating blank, set arrival altimeter — share URL and reload — arrival value should be in arrival column, not operating

🤖 Generated with [Claude Code](https://claude.com/claude-code)