### PR TITLE
Fix Vx showing 0 for C206

### DIFF
--- a/src/data/aircraft.json
+++ b/src/data/aircraft.json
@@ -469,6 +469,10 @@
         [230, 120, null, null]
       ]
     },
+    "Vx": {
+      "speeds": [89, 89, 79],
+      "altitudes": [0, 17000, 24000]
+    },
     "shortFieldTakeoff": {
       "weights": [3000, 3300, 3600],
       "pressureAltitudes": [0, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000],


### PR DESCRIPTION
## Summary
- Adds missing `Vx` data for C206 in `aircraft.json`
- Vx values from POH: 89 kts (0–17,000 ft), 79 kts (24,000 ft)

## Test plan
- [ ] Select C206 as aircraft type
- [ ] Verify Vx (Best Angle) row shows non-zero values in the Climb Performance table

Closes #43