### PR TITLE
Fix #41: Distinguish null from 0 in weather table and URL state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,14 +40,16 @@ The application uses URL query strings to persist application state, allowing us
 **Serialization Approach:**
 - Uses the `qs` library (https://github.com/ljharb/qs) for query string handling
 - Query strings are optimized for compactness and human-readability
-- Configuration: `{arrayFormat: 'comma', encode: false, skipNulls: true}`
+- Configuration: `{arrayFormat: 'comma', encode: true, skipNulls: true}` with a custom encoder that converts spaces to `+`
 
 **Format Details:**
 - **Arrays**: Comma-separated values (e.g., `?numbers=1,2,3`)
 - **Booleans**: Serialized as "1" or "0" (e.g., `?turb=1`)
-- **Nested Arrays (2D)**: Custom format with `||` separator (e.g., `?wind=0,90,180||5,10,15`)
-- **Empty values**: Null/undefined top-level values and fully-empty arrays are omitted. However, null elements *within* a fixed-length array are preserved as empty slots (e.g. `[30.24, null, 30.31]` → `altimeter=30.24,,30.31`) so that array indices are stable across round-trips. Deserialization restores empty slots back to `null`.
-- **No URL encoding**: Values are stored as-is for readability (e.g., `?pilot=John+Doe` not `?pilot=John%20Doe`)
+- **Nested Arrays (2D)**: Custom format with `||` separator (e.g., `?wind=,90,180||5,10,15`). Null positions are preserved as empty slots (e.g. `[null, 90, 180]` → `,90,180`).
+- **Empty values**: Null/undefined top-level values and fully-empty arrays are omitted. However, null elements *within* any array (simple or nested) are preserved as empty slots so that array indices are stable across round-trips. Deserialization restores empty slots back to `null`.
+- **Spaces**: Encoded as `+` for readability (e.g., `?pilot=John+Doe` not `?pilot=John%20Doe`)
+
+**Wind data null semantics:** The `wind` field uses `null` (not `0`) to represent missing data for an altitude. A value of `0` is a legitimate wind direction or velocity. This distinction matters in both the URL (`wind=,255,257` means null at 3,000ft, not zero) and in rendering (`??` not `||` must be used when reading values for display).
 
 **Type Hints:**
 - Deserialization uses `initialState` as type hints to properly convert strings back to numbers, booleans, etc.

--- a/src/components/AppContainer.tsx
+++ b/src/components/AppContainer.tsx
@@ -41,10 +41,10 @@ export default function AppContainer() {
 
     // Weather Information
     wind: [
-      Array(5).fill(0) as number[], // wDir values for 3k,6k,9k,12k,15k
-      Array(5).fill(0) as number[], // wVel values for 3k,6k,9k,12k,15k
-      Array(5).fill(0) as number[], // temp values for 3k,6k,9k,12k,15k
-    ] as [number[], number[], number[]],
+      Array(5).fill(null) as (number | null)[], // wDir values for 3k,6k,9k,12k,15k
+      Array(5).fill(null) as (number | null)[], // wVel values for 3k,6k,9k,12k,15k
+      Array(5).fill(null) as (number | null)[], // temp values for 3k,6k,9k,12k,15k
+    ] as [(number | null)[], (number | null)[], (number | null)[]],
     turb: false,
     cielVis: false,
     mtnObsc: false,

--- a/src/components/WeatherInfo.test.tsx
+++ b/src/components/WeatherInfo.test.tsx
@@ -12,9 +12,9 @@ describe("WeatherInfo", () => {
     onUpdate: jest.fn(),
     initialData: {
       wind: [
-        [0, 0, 0, 0, 0],
-        [0, 0, 0, 0, 0],
-        [0, 0, 0, 0, 0],
+        [null, null, null, null, null],
+        [null, null, null, null, null],
+        [null, null, null, null, null],
       ],
       turb: false,
       cielVis: false,
@@ -35,9 +35,9 @@ describe("WeatherInfo", () => {
     const worksheetDataWithApi: WorksheetData = {
       ...defaultProps.initialData,
       wind: [
-        [270, 0, 0, 0, 0],
-        [25, 0, 0, 0, 0],
-        [15, 0, 0, 0, 0],
+        [270, null, null, null, null],
+        [25, null, null, null, null],
+        [15, null, null, null, null],
       ],
       temp: [18, 18, 18],
       altimeter: [29.85, 29.85, 29.85],
@@ -56,9 +56,9 @@ describe("WeatherInfo", () => {
     const worksheetDataManual: WorksheetData = {
       ...defaultProps.initialData,
       wind: [
-        [0, 0, 0, 0, 0],
-        [0, 0, 0, 0, 0],
-        [0, 0, 0, 0, 0],
+        [null, null, null, null, null],
+        [null, null, null, null, null],
+        [null, null, null, null, null],
       ],
     };
 

--- a/src/components/WeatherInfo.tsx
+++ b/src/components/WeatherInfo.tsx
@@ -17,9 +17,9 @@ const altitudes = ["3,000", "6,000", "9,000", "12,000", "15,000"];
 
 const DEFAULT_WEATHER_DATA: WeatherFields = {
   wind: [
-    Array(5).fill(0), // wDir values for 3k,6k,9k,12k,15k
-    Array(5).fill(0), // wVel values for 3k,6k,9k,12k,15k
-    Array(5).fill(0), // temp values for 3k,6k,9k,12k,15k
+    Array(5).fill(null) as (number | null)[], // wDir values for 3k,6k,9k,12k,15k
+    Array(5).fill(null) as (number | null)[], // wVel values for 3k,6k,9k,12k,15k
+    Array(5).fill(null) as (number | null)[], // temp values for 3k,6k,9k,12k,15k
   ],
   turb: false,
   cielVis: false,
@@ -61,8 +61,8 @@ export default function WeatherInfo({
 
   // Helper to deep compare arrays
   const arraysEqual = (
-    a: number[] | undefined,
-    b: number[] | undefined
+    a: (number | null)[] | undefined,
+    b: (number | null)[] | undefined
   ): boolean => {
     if (!a || !b) return a === b;
     if (a.length !== b.length) return false;
@@ -71,8 +71,8 @@ export default function WeatherInfo({
 
   // Helper to deep compare wind arrays (3D array)
   const windArraysEqual = (
-    a: [number[], number[], number[]] | undefined,
-    b: [number[], number[], number[]] | undefined
+    a: [(number | null)[], (number | null)[], (number | null)[]] | undefined,
+    b: [(number | null)[], (number | null)[], (number | null)[]] | undefined
   ): boolean => {
     if (!a || !b) return a === b;
     if (a.length !== b.length) return false;
@@ -124,7 +124,7 @@ export default function WeatherInfo({
 
         // Only update wind if it's API-populated and should be updated
         if (shouldUpdateWind && initialData.wind) {
-          updates.wind = initialData.wind as [number[], number[], number[]];
+          updates.wind = initialData.wind as [(number | null)[], (number | null)[], (number | null)[]];
         }
 
         // Preserve user edits to non-API fields (turb, cielVis, mtnObsc)
@@ -150,7 +150,7 @@ export default function WeatherInfo({
     initialData.wind.length === 3 &&
     initialData.wind[0] &&
     Array.isArray(initialData.wind[0]) &&
-    initialData.wind[0].some((val) => val !== 0);
+    initialData.wind[0].some((val) => val !== null && val !== undefined);
 
   const displayData = hasApiWindData
     ? {
@@ -186,26 +186,28 @@ export default function WeatherInfo({
     index: number, // 0 for 3k, 1 for 6k, etc.
     value: string
   ) => {
-    const numValue = value === "" ? 0 : Number(value);
+    const numValue: number | null = value === "" ? null : Number(value);
     let isValid = true;
 
-    switch (type) {
-      case 0: // wDir
-        isValid =
-          numValue >= 0 && numValue <= 359 && Number.isInteger(numValue);
-        break;
-      case 1: // wVel
-        isValid =
-          numValue >= 0 && numValue <= 150 && Number.isInteger(numValue);
-        break;
-      case 2: // temp
-        isValid =
-          numValue >= -50 && numValue <= 50 && Number.isInteger(numValue);
-        break;
+    if (numValue !== null) {
+      switch (type) {
+        case 0: // wDir
+          isValid =
+            numValue >= 0 && numValue <= 359 && Number.isInteger(numValue);
+          break;
+        case 1: // wVel
+          isValid =
+            numValue >= 0 && numValue <= 150 && Number.isInteger(numValue);
+          break;
+        case 2: // temp
+          isValid =
+            numValue >= -50 && numValue <= 50 && Number.isInteger(numValue);
+          break;
+      }
     }
 
     if (isValid) {
-      const newWind = [...data.wind] as [number[], number[], number[]];
+      const newWind = [...data.wind] as [(number | null)[], (number | null)[], (number | null)[]];
       newWind[type] = [...newWind[type]];
       newWind[type][index] = numValue;
       const newData = {
@@ -269,7 +271,7 @@ export default function WeatherInfo({
                   type="number"
                   min={0}
                   max={359}
-                  value={displayData.wind?.[0]?.[altitudes.indexOf(alt)] || ""}
+                  value={displayData.wind?.[0]?.[altitudes.indexOf(alt)] ?? ""}
                   onChange={(e) =>
                     handleNumericChange(
                       0,
@@ -290,7 +292,7 @@ export default function WeatherInfo({
                   type="number"
                   min={0}
                   max={150}
-                  value={displayData.wind?.[1]?.[altitudes.indexOf(alt)] || ""}
+                  value={displayData.wind?.[1]?.[altitudes.indexOf(alt)] ?? ""}
                   onChange={(e) =>
                     handleNumericChange(
                       1,
@@ -311,7 +313,7 @@ export default function WeatherInfo({
                   type="number"
                   min={-50}
                   max={50}
-                  value={displayData.wind?.[2]?.[altitudes.indexOf(alt)] || ""}
+                  value={displayData.wind?.[2]?.[altitudes.indexOf(alt)] ?? ""}
                   onChange={(e) =>
                     handleNumericChange(
                       2,

--- a/src/utils/__tests__/urlState.test.ts
+++ b/src/utils/__tests__/urlState.test.ts
@@ -1,5 +1,131 @@
-import { serializeState, deserializeState } from "../urlState";
+import { serializeState, deserializeState, convertSingleValue } from "../urlState";
 import qs from "qs";
+
+describe("convertSingleValue", () => {
+  describe("null/empty string handling", () => {
+    it("should convert empty string to null", () => {
+      expect(convertSingleValue("", "string")).toBeNull();
+      expect(convertSingleValue("", 0)).toBeNull();
+      expect(convertSingleValue("", false)).toBeNull();
+    });
+  });
+
+  describe("string type hints", () => {
+    it("should return string value when typeHint is string", () => {
+      expect(convertSingleValue("hello", "hint")).toBe("hello");
+      expect(convertSingleValue("123", "hint")).toBe("123");
+      expect(convertSingleValue("true", "hint")).toBe("true");
+    });
+  });
+
+  describe("boolean type hints", () => {
+    it('should convert "1" to true when typeHint is boolean', () => {
+      expect(convertSingleValue("1", false)).toBe(true);
+      expect(convertSingleValue("1", true)).toBe(true);
+    });
+
+    it('should convert "true" to true when typeHint is boolean', () => {
+      expect(convertSingleValue("true", false)).toBe(true);
+    });
+
+    it('should convert "0" to false when typeHint is boolean', () => {
+      expect(convertSingleValue("0", false)).toBe(false);
+    });
+
+    it('should convert other values to false when typeHint is boolean', () => {
+      expect(convertSingleValue("false", false)).toBe(false);
+      expect(convertSingleValue("no", false)).toBe(false);
+      expect(convertSingleValue("", false)).toBeNull(); // empty string is null
+    });
+  });
+
+  describe("number type hints", () => {
+    it("should convert to number when typeHint is number", () => {
+      expect(convertSingleValue("42", 0)).toBe(42);
+      expect(convertSingleValue("0", 0)).toBe(0);
+      expect(convertSingleValue("-5", 0)).toBe(-5);
+      expect(convertSingleValue("3.14", 0)).toBe(3.14);
+    });
+
+    it("should handle positive numbers with + prefix", () => {
+      expect(convertSingleValue("+42", 0)).toBe(42);
+      expect(convertSingleValue("+3.14", 0)).toBe(3.14);
+    });
+
+    it("should handle negative numbers", () => {
+      expect(convertSingleValue("-42", 0)).toBe(-42);
+      expect(convertSingleValue("-3.14", 0)).toBe(-3.14);
+    });
+
+    it("should handle zero", () => {
+      expect(convertSingleValue("0", 0)).toBe(0);
+      expect(convertSingleValue("-0", 0)).toBe(-0);
+    });
+  });
+
+  describe("automatic number detection (no type hint)", () => {
+    it("should auto-detect and convert number-like strings when they match the pattern", () => {
+      expect(convertSingleValue("42", undefined)).toBe(42);
+      expect(convertSingleValue("3.14", null)).toBe(3.14);
+    });
+
+    it("should not convert strings with non-number type hints", () => {
+      // When typeHint is not a number and value has non-numeric chars, keep as string
+      expect(convertSingleValue("-5", "unknown")).toBe("-5");
+    });
+
+    it("should not convert non-numeric strings to numbers", () => {
+      expect(convertSingleValue("hello", undefined)).toBe("hello");
+      expect(convertSingleValue("123abc", null)).toBe("123abc");
+      expect(convertSingleValue("abc123", undefined)).toBe("abc123");
+    });
+
+    it("should handle numbers with leading/trailing whitespace when no type hint", () => {
+      // The regex checks v.trim(), so whitespace is handled
+      expect(convertSingleValue(" 42 ", undefined)).toBe(" 42 "); // Preserves original with spaces
+      // But when typeHint is number, it converts
+      expect(convertSingleValue(" 42 ", 0)).toBe(42);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle whitespace-only strings", () => {
+      expect(convertSingleValue("   ", undefined)).toBe("   ");
+      expect(convertSingleValue("\t\n", null)).toBe("\t\n");
+    });
+
+    it("should handle special numeric strings", () => {
+      expect(convertSingleValue("0.0", 0)).toBe(0);
+      expect(convertSingleValue("1.0", 0)).toBe(1);
+      expect(convertSingleValue(".5", 0)).toBe(0.5);
+    });
+
+    it("should handle invalid number strings when typeHint is number", () => {
+      // When typeHint is number, Number() is called even on invalid strings
+      expect(isNaN(convertSingleValue("1.2.3", 0) as number)).toBe(true);
+      expect(convertSingleValue("1e5", 0)).toBe(100000); // Scientific notation works
+    });
+
+    it("should handle scientific notation correctly", () => {
+      expect(convertSingleValue("1e5", 0)).toBe(100000);
+      expect(convertSingleValue("1.5e2", 0)).toBe(150);
+      expect(convertSingleValue("-1e3", 0)).toBe(-1000);
+    });
+  });
+
+  describe("null vs zero distinction", () => {
+    it("should distinguish between null (empty string) and 0 (zero string)", () => {
+      expect(convertSingleValue("", 0)).toBeNull();
+      expect(convertSingleValue("0", 0)).toBe(0);
+    });
+
+    it("should distinguish between null and negative zero", () => {
+      expect(convertSingleValue("", 0)).toBeNull();
+      expect(convertSingleValue("-0", 0)).toBe(-0);
+    });
+  });
+});
+
 
 describe("serializeState", () => {
   it("should serialize primitive values correctly", () => {

--- a/src/utils/__tests__/urlState.test.ts
+++ b/src/utils/__tests__/urlState.test.ts
@@ -76,6 +76,34 @@ describe("serializeState", () => {
     expect(params.get("mixed")).toBe("1,a||b,2");
   });
 
+  it("should preserve null positions in nested arrays", () => {
+    // Regression test for issue #41: null slots must be preserved as empty strings
+    // so that 0 and null are distinguishable in the URL.
+    const state = {
+      wind: [
+        [null, 255, 257],
+        [null, 0, 15],
+        [null, -2, -8],
+      ],
+    };
+    const queryString = serializeState(state as Record<string, unknown>);
+    const params = new URLSearchParams(queryString);
+    expect(params.get("wind")).toBe(",255,257||,0,15||,-2,-8");
+  });
+
+  it("should omit nested array key when all values are null", () => {
+    const state = {
+      wind: [
+        [null, null, null],
+        [null, null, null],
+        [null, null, null],
+      ],
+    };
+    const queryString = serializeState(state as Record<string, unknown>);
+    const params = new URLSearchParams(queryString);
+    expect(params.has("wind")).toBe(false);
+  });
+
   it("should handle complex state objects", () => {
     const state = {
       pilot: "John Doe",
@@ -240,5 +268,27 @@ describe("deserializeState", () => {
     const restored = deserializeState(serialized, initialState);
     expect(restored.altimeter).toEqual([30.24, null, 30.31]);
     expect(restored.temp).toEqual([null, 5, -2]);
+  });
+
+  it("should round-trip nested arrays with null and zero values", () => {
+    // Regression test for issue #41: null and 0 must be distinguishable after
+    // serialization and deserialization. null → empty slot, 0 → "0".
+    const originalState = {
+      wind: [
+        [null, 255, 257, 272, 281],
+        [null, 0, 15, 26, 30],
+        [null, -2, -8, -12, -17],
+      ] as (number | null)[][],
+    };
+    const serialized = serializeState(originalState as Record<string, unknown>);
+    const initialState = {
+      wind: [
+        Array(5).fill(null),
+        Array(5).fill(null),
+        Array(5).fill(null),
+      ] as (number | null)[][],
+    };
+    const restored = deserializeState(serialized, initialState);
+    expect(restored.wind).toEqual(originalState.wind);
   });
 });

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -12,7 +12,7 @@ export interface WorksheetData {
   route: string; // Area of Operations/Route
 
   // Weather Information
-  wind: [number[], number[], number[]]; // [wDir, wVel, temp] arrays for each altitude
+  wind: [(number | null)[], (number | null)[], (number | null)[]]; // [wDir, wVel, temp] arrays for each altitude
   turb: boolean;
   cielVis: boolean;
   mtnObsc: boolean;

--- a/src/utils/urlState.ts
+++ b/src/utils/urlState.ts
@@ -57,18 +57,20 @@ const preprocessForQs = (state: Record<string, unknown>): Record<string, unknown
     
     // Handle nested arrays (2D arrays) - serialize them as comma-separated strings with || separator
     // This is the only custom format we need since qs doesn't support || separator natively
+    // Null/undefined positions are preserved as empty slots (e.g. [null, 0, 5] → ",0,5")
+    // so that index positions round-trip correctly (deserialization restores "" to null).
     if (Array.isArray(value) && value.length > 0 && Array.isArray(value[0])) {
       const nestedSerialized = value.map((subArray) => {
-        const filtered = subArray.filter(
-          (v: unknown) => v !== null && v !== undefined && v !== ""
-        );
-        const mapped = filtered.map((v: unknown) => {
+        const mapped = subArray.map((v: unknown) => {
+          if (v === null || v === undefined || v === "") return "";
           if (typeof v === "boolean") return v ? "1" : "0";
           return String(v);
         });
         return mapped.join(",");
       });
-      processed[key] = nestedSerialized.join("||");
+      // Only include the key if at least one sub-array has a non-empty value
+      const hasAnyValue = nestedSerialized.some((s) => s.replace(/,/g, "") !== "");
+      processed[key] = hasAnyValue ? nestedSerialized.join("||") : undefined;
       continue;
     }
     
@@ -162,18 +164,37 @@ const postprocessState = <T>(
     }
 
     const hint = initial[key];
-    
-    // Handle nested arrays (check for || separator - our custom format)
-    if (typeof value === "string" && value.includes("||")) {
-      const subArrays = value.split("||");
+
+    // Handle nested arrays (our custom || separator format).
+    // qs parses the comma-separated portion but leaves || inside element strings,
+    // so we rejoin with commas and split on || to reconstruct sub-arrays.
+    const rawStr = Array.isArray(value)
+      ? (value as unknown[]).join(",")
+      : typeof value === "string"
+        ? value
+        : null;
+
+    if (rawStr !== null && rawStr.includes("||")) {
+      const subArrays = rawStr.split("||");
       const reconstructed = subArrays.map((subArrayStr) => {
         if (!subArrayStr) return [];
         return subArrayStr.split(",").map((v, i) => {
+          // Empty slot → null (preserved null position)
+          if (v === "") return null;
+
           const typeHint = Array.isArray(hint) && hint.length > 0 && Array.isArray(hint[0])
             ? (hint[0] as unknown[])[i] ?? (hint[0] as unknown[]).find((h) => h !== null && h !== undefined)
             : hint;
-          
-          return convertValue(v, typeHint);
+
+          // If typeHint is a number or value looks like a number, convert it
+          if (
+            typeof typeHint === "number" ||
+            (v.trim() !== "" && /^[+-]?\d+(\.\d+)?$/.test(v))
+          ) {
+            return Number(v);
+          }
+          if (typeof typeHint === "boolean") return v === "1" || v === "true";
+          return v;
         });
       });
       (result as Record<string, unknown>)[key] = reconstructed;

--- a/src/utils/urlState.ts
+++ b/src/utils/urlState.ts
@@ -92,6 +92,26 @@ const preprocessForQs = (state: Record<string, unknown>): Record<string, unknown
   return processed;
 };
 
+// Shared helper function to convert a single value based on a type hint
+// Used by both convertValue (for simple arrays) and postprocessState (for nested arrays)
+// This handles type coercion (string -> number, "1"/"0" -> boolean, etc.)
+// Exported for testing purposes
+export const convertSingleValue = (v: string, typeHint: unknown): unknown => {
+  // Empty string is a preserved null position (from serialization of null array
+  // elements as "" to maintain index positions). Restore to null.
+  if (v === "") return null;
+
+  if (typeof typeHint === "string") return v;
+  if (typeof typeHint === "boolean") return v === "1" || v === "true";
+  if (
+    typeof typeHint === "number" ||
+    (v.trim() !== "" && /^[+-]?\d+(\.\d+)?$/.test(v))
+  ) {
+    return Number(v);
+  }
+  return v;
+};
+
 // Helper function to convert values based on type hints from initialState
 // This handles type coercion (string -> number, "1"/"0" -> boolean, etc.)
 const convertValue = (value: unknown, hint: unknown): unknown => {
@@ -111,19 +131,7 @@ const convertValue = (value: unknown, hint: unknown): unknown => {
       const typeHint =
         (hint as unknown[])[i] ?? (hint as unknown[]).find((h) => h !== null && h !== undefined);
 
-      // Empty string is a preserved null position (from serialization of null array
-      // elements as "" to maintain index positions). Restore to null.
-      if (vStr === "") return null;
-
-      if (typeof typeHint === "string") return vStr;
-      if (typeof typeHint === "boolean") return vStr === "1" || vStr === "true";
-      if (
-        typeof typeHint === "number" ||
-        (vStr.trim() !== "" && /^[+-]?\d+(\.\d+)?$/.test(vStr))
-      ) {
-        return Number(vStr);
-      }
-      return vStr;
+      return convertSingleValue(vStr, typeHint);
     });
     
     // Check if hint suggests nested array but we got flat string (backward compatibility)
@@ -179,22 +187,11 @@ const postprocessState = <T>(
       const reconstructed = subArrays.map((subArrayStr) => {
         if (!subArrayStr) return [];
         return subArrayStr.split(",").map((v, i) => {
-          // Empty slot → null (preserved null position)
-          if (v === "") return null;
-
           const typeHint = Array.isArray(hint) && hint.length > 0 && Array.isArray(hint[0])
             ? (hint[0] as unknown[])[i] ?? (hint[0] as unknown[]).find((h) => h !== null && h !== undefined)
             : hint;
 
-          // If typeHint is a number or value looks like a number, convert it
-          if (
-            typeof typeHint === "number" ||
-            (v.trim() !== "" && /^[+-]?\d+(\.\d+)?$/.test(v))
-          ) {
-            return Number(v);
-          }
-          if (typeof typeHint === "boolean") return v === "1" || v === "true";
-          return v;
+          return convertSingleValue(v, typeHint);
         });
       });
       (result as Record<string, unknown>)[key] = reconstructed;

--- a/src/utils/weatherDataMapper.test.ts
+++ b/src/utils/weatherDataMapper.test.ts
@@ -57,18 +57,18 @@ describe("Weather Data Mapper", () => {
       const result = mapWindTempData(mockWindTempData);
 
       expect(result.wind).toBeDefined();
-      expect(result.wind![0]).toEqual([270, 280, 290, 0, 0]); // Wind direction
-      expect(result.wind![1]).toEqual([25, 30, 35, 0, 0]); // Wind speed
-      expect(result.wind![2]).toEqual([15, 10, 5, 0, 0]); // Temperature
+      expect(result.wind![0]).toEqual([270, 280, 290, null, null]); // Wind direction
+      expect(result.wind![1]).toEqual([25, 30, 35, null, null]); // Wind speed
+      expect(result.wind![2]).toEqual([15, 10, 5, null, null]); // Temperature
     });
 
     it("should handle empty wind/temperature data", () => {
       const result = mapWindTempData([]);
 
       expect(result.wind).toBeDefined();
-      expect(result.wind![0]).toEqual([0, 0, 0, 0, 0]);
-      expect(result.wind![1]).toEqual([0, 0, 0, 0, 0]);
-      expect(result.wind![2]).toEqual([0, 0, 0, 0, 0]);
+      expect(result.wind![0]).toEqual([null, null, null, null, null]);
+      expect(result.wind![1]).toEqual([null, null, null, null, null]);
+      expect(result.wind![2]).toEqual([null, null, null, null, null]);
     });
 
     it("should find closest altitude data within 2000 feet", () => {
@@ -114,7 +114,7 @@ describe("Weather Data Mapper", () => {
 
       const result = mapWindTempData(dataWithFarAltitudes);
 
-      expect(result.wind![0][0]).toBe(0); // Should remain 0
+      expect(result.wind![0][0]).toBe(null); // Should remain null (no data)
     });
 
     it("should validate data when validation is enabled", () => {
@@ -132,9 +132,9 @@ describe("Weather Data Mapper", () => {
 
       const result = mapWindTempData(invalidData, { validateData: true });
 
-      expect(result.wind![0][0]).toBe(0); // Should remain 0 due to validation
-      expect(result.wind![1][0]).toBe(0); // Should remain 0 due to validation
-      expect(result.wind![2][0]).toBe(0); // Should remain 0 due to validation
+      expect(result.wind![0][0]).toBe(null); // Should remain null due to validation
+      expect(result.wind![1][0]).toBe(null); // Should remain null due to validation
+      expect(result.wind![2][0]).toBe(null); // Should remain null due to validation
     });
   });
 
@@ -785,9 +785,9 @@ describe("Weather Data Mapper", () => {
     it("should detect null values as not API-populated", () => {
       const data = {
         wind: [
-          [0, 0, 0, 0, 0],
-          [0, 0, 0, 0, 0],
-          [0, 0, 0, 0, 0],
+          [null, null, null, null, null],
+          [null, null, null, null, null],
+          [null, null, null, null, null],
         ],
         temp: [null, null, null],
         altimeter: [null, null, null],

--- a/src/utils/weatherDataMapper.ts
+++ b/src/utils/weatherDataMapper.ts
@@ -49,7 +49,7 @@ export function mapWindTempData(
   options: WeatherMappingOptions = {}
 ): Partial<WorksheetData> {
   const result: Partial<WorksheetData> = {
-    wind: [Array(5).fill(0), Array(5).fill(0), Array(5).fill(0)],
+    wind: [Array(5).fill(null), Array(5).fill(null), Array(5).fill(null)],
   };
 
   // Group data by altitude
@@ -684,7 +684,7 @@ function validateMappedData(data: Partial<WorksheetData>): {
   // Validate wind data
   if (data.wind) {
     data.wind[0].forEach((dir, index) => {
-      if (dir !== 0 && !isValidWindDirection(dir)) {
+      if (dir !== null && dir !== undefined && !isValidWindDirection(dir)) {
         errors.push(
           `Invalid wind direction at altitude ${TARGET_ALTITUDES[index]}ft: ${dir}`
         );
@@ -692,7 +692,7 @@ function validateMappedData(data: Partial<WorksheetData>): {
     });
 
     data.wind[1].forEach((speed, index) => {
-      if (speed !== 0 && !isValidWindSpeed(speed)) {
+      if (speed !== null && speed !== undefined && !isValidWindSpeed(speed)) {
         errors.push(
           `Invalid wind speed at altitude ${TARGET_ALTITUDES[index]}ft: ${speed}`
         );
@@ -700,7 +700,7 @@ function validateMappedData(data: Partial<WorksheetData>): {
     });
 
     data.wind[2].forEach((temp, index) => {
-      if (temp !== 0 && !isValidTemperature(temp)) {
+      if (temp !== null && temp !== undefined && !isValidTemperature(temp)) {
         errors.push(
           `Invalid temperature at altitude ${TARGET_ALTITUDES[index]}ft: ${temp}`
         );
@@ -754,7 +754,7 @@ export function isApiPopulatedData(data: Partial<WorksheetData>): {
     wind: !!(
       data.wind &&
       Array.isArray(data.wind[0]) &&
-      data.wind[0].some((val) => val !== 0)
+      data.wind[0].some((val) => val !== null && val !== undefined)
     ),
     temperature: !!(
       data.temp &&


### PR DESCRIPTION
## Summary
Resolves issue #41 by properly distinguishing between `null` (missing data) and `0` (valid value) in weather data, particularly for wind information.

## Changes

### Type System Updates
- Updated `wind` field type from `[number[], number[], number[]]` to `[(number | null)[], (number | null)[], (number | null)[]]` in `WorksheetData` interface
- Changed initial state to use `null` instead of `0` as default values

### Weather Data Handling
- Modified `WeatherInfo.tsx` to use `??` (nullish coalescing) instead of `||` for proper null handling
- Updated validation logic to only check ranges when value is not `null`
- Fixed `mapWindTempData()` to initialize wind arrays with `null` instead of `0`
- Updated wind data population detection to check for `null` values

### URL State Serialization
- Enhanced `urlState.ts` to preserve null positions in nested arrays as empty slots
  - Example: `[null, 255, 257]` → `,255,257` (not `255,257`)
  - Allows round-trip distinction between missing data (null) and zero values
- Added logic to omit nested array key entirely when all values are null
- Updated deserialization to restore empty slots back to `null`

### Documentation
- Updated `AGENTS.md` with clarified null semantics for wind data
- Added note that `0` is a legitimate wind value and must be distinguished from `null`

### Tests
- Updated all test expectations to use `null` instead of `0` for unset wind values
- Added regression tests for null/zero distinguishability in round-trip serialization