### PR TITLE
Fix #55: correct 'Cieling' typo to 'Ceiling'

### DIFF
--- a/src/components/WeatherInfo.tsx
+++ b/src/components/WeatherInfo.tsx
@@ -367,7 +367,7 @@ export default function WeatherInfo({
               rel="noopener noreferrer"
               className="text-blue-600 dark:text-blue-400 hover:underline"
             >
-              Cieling/Vis
+              Ceiling/Vis
             </a>
           </label>
         </div>


### PR DESCRIPTION
## Summary
- Fixes typo in `WeatherInfo.tsx`: `Cieling/Vis` → `Ceiling/Vis`

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)