### PR TITLE
Fix #58: Consolidate user inputs — move Operating Altitude to first section

### DIFF
--- a/src/components/AircraftPerformance.test.tsx
+++ b/src/components/AircraftPerformance.test.tsx
@@ -77,9 +77,11 @@ describe("AircraftPerformance", () => {
     const altimeterInputs = screen.getAllByDisplayValue("29.92");
     expect(altimeterInputs).toHaveLength(3);
 
-    // Check altitude inputs
+    // Operating altitude is now read-only text; only departure and arrival are inputs
     const altitudeInputs = screen.getAllByDisplayValue("8000");
-    expect(altitudeInputs).toHaveLength(3);
+    expect(altitudeInputs).toHaveLength(2);
+    // Operating altitude shown as text
+    expect(screen.getByText("8000")).toBeInTheDocument();
 
     // Check runway inputs
     const runwayInputs = screen.getAllByDisplayValue("1000");
@@ -188,7 +190,9 @@ describe("AircraftPerformance", () => {
       />
     );
 
+    // Operating altitude is now read-only; only departure and arrival are inputs
     const altitudeInputs = screen.getAllByDisplayValue("8000");
+    expect(altitudeInputs).toHaveLength(2);
 
     // Test departure altitude change
     fireEvent.change(altitudeInputs[0], { target: { value: "4471" } });
@@ -200,18 +204,8 @@ describe("AircraftPerformance", () => {
       rwy: [1000, 1000],
     });
 
-    // Test operating altitude change
-    fireEvent.change(altitudeInputs[1], { target: { value: "9000" } });
-    expect(mockOnUpdate).toHaveBeenCalledWith({
-      airport: ["KOGD", "KSLC"],
-      temp: [21, 21, 21],
-      altimeter: [29.92, 29.92, 29.92],
-      altitude: [8000, 9000, 8000],
-      rwy: [1000, 1000],
-    });
-
     // Test arrival altitude change
-    fireEvent.change(altitudeInputs[2], { target: { value: "4229" } });
+    fireEvent.change(altitudeInputs[1], { target: { value: "4229" } });
     expect(mockOnUpdate).toHaveBeenCalledWith({
       airport: ["KOGD", "KSLC"],
       temp: [21, 21, 21],
@@ -358,9 +352,8 @@ describe("AircraftPerformance", () => {
     const arrivalAltitudeInput = screen.getByDisplayValue("4229");
     expect(arrivalAltitudeInput).toHaveClass("bg-blue-50", "border-blue-300");
 
-    // Check that operating altitude (8000) has manual styling
-    const operatingAltitudeInput = screen.getByDisplayValue("8000");
-    expect(operatingAltitudeInput).toHaveClass("bg-white", "border-gray-300");
+    // Operating altitude is now read-only text (moved to SortieInfo)
+    expect(screen.getByText("8000")).toBeInTheDocument();
   });
 
   it("applies manual styling to fields when data is not API-populated", () => {
@@ -494,7 +487,9 @@ describe("AircraftPerformance", () => {
     // Should display initialData values
     expect(screen.getAllByDisplayValue("21")).toHaveLength(3);
     expect(screen.getAllByDisplayValue("1000")).toHaveLength(2);
-    expect(screen.getAllByDisplayValue("8000")).toHaveLength(3);
+    // Operating altitude is read-only text; departure and arrival remain as inputs
+    expect(screen.getAllByDisplayValue("8000")).toHaveLength(2);
+    expect(screen.getByText("8000")).toBeInTheDocument();
   });
 
   it("handles partial worksheetData updates", () => {
@@ -517,6 +512,8 @@ describe("AircraftPerformance", () => {
 
     // Should display initialData for temp and altitude
     expect(screen.getAllByDisplayValue("21")).toHaveLength(3);
-    expect(screen.getAllByDisplayValue("8000")).toHaveLength(3);
+    // Operating altitude is read-only text; departure and arrival remain as inputs
+    expect(screen.getAllByDisplayValue("8000")).toHaveLength(2);
+    expect(screen.getByText("8000")).toBeInTheDocument();
   });
 });

--- a/src/components/AircraftPerformance.tsx
+++ b/src/components/AircraftPerformance.tsx
@@ -363,14 +363,9 @@ export default function AircraftPerformance({
                 />
               </td>
               <td className="p-2">
-                <input
-                  type="number"
-                  value={getValue("altitude", 1)}
-                  onChange={(e) =>
-                    handleInputChange("altitude", 1, e.target.value)
-                  }
-                  className={getInputStyling("altitude", 1)}
-                />
+                <span className="text-gray-700 dark:text-gray-300">
+                  {getValue("altitude", 1) || "—"}
+                </span>
               </td>
               <td className="p-2">
                 <input

--- a/src/components/SortieInfo.test.tsx
+++ b/src/components/SortieInfo.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import SortieInfo from "./SortieInfo";
+import type { WorksheetData } from "@/utils/types";
+
+const defaultInitialData: WorksheetData = {
+  pilot: "",
+  date: "",
+  time: "",
+  acType: "",
+  tailN: "",
+  airport: ["", ""],
+  route: "",
+  weight: null,
+  altitude: [null, null, null],
+  wind: [Array(5).fill(null), Array(5).fill(null), Array(5).fill(null)],
+  turb: false,
+  cielVis: false,
+  mtnObsc: false,
+  temp: [null, null, null],
+  altimeter: [null, null, null],
+  rwy: [null, null],
+  mtnEndorse: false,
+  mtnCert: false,
+};
+
+describe("SortieInfo", () => {
+  const mockOnUpdate = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the operating altitude input", () => {
+    render(<SortieInfo onUpdate={mockOnUpdate} initialData={defaultInitialData} />);
+    expect(screen.getByLabelText(/Operating Altitude/i)).toBeInTheDocument();
+  });
+
+  it("displays operating altitude label as 'Area of Operations (position)'", () => {
+    render(<SortieInfo onUpdate={mockOnUpdate} initialData={defaultInitialData} />);
+    expect(screen.getByLabelText("Area of Operations (position)")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Area of Operations/Route")).not.toBeInTheDocument();
+  });
+
+  it("populates operating altitude from initialData", () => {
+    const initialData = { ...defaultInitialData, altitude: [4471, 9000, 4229] as [number | null, number | null, number | null] };
+    render(<SortieInfo onUpdate={mockOnUpdate} initialData={initialData} />);
+    const input = screen.getByLabelText(/Operating Altitude/i) as HTMLInputElement;
+    expect(input.value).toBe("9000");
+  });
+
+  it("calls onUpdate with updated altitude[1] when operating altitude changes", () => {
+    const initialData = { ...defaultInitialData, altitude: [4471, null, 4229] as [number | null, number | null, number | null] };
+    render(<SortieInfo onUpdate={mockOnUpdate} initialData={initialData} />);
+    const input = screen.getByLabelText(/Operating Altitude/i);
+    fireEvent.change(input, { target: { value: "9000" } });
+    expect(mockOnUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ altitude: [4471, 9000, 4229] })
+    );
+  });
+
+  it("preserves departure and arrival altitude when operating altitude changes", () => {
+    const initialData = { ...defaultInitialData, altitude: [5000, 8000, 3500] as [number | null, number | null, number | null] };
+    render(<SortieInfo onUpdate={mockOnUpdate} initialData={initialData} />);
+    const input = screen.getByLabelText(/Operating Altitude/i);
+    fireEvent.change(input, { target: { value: "10000" } });
+    expect(mockOnUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ altitude: [5000, 10000, 3500] })
+    );
+  });
+
+  it("clears operating altitude when input is empty", () => {
+    const initialData = { ...defaultInitialData, altitude: [4471, 9000, 4229] as [number | null, number | null, number | null] };
+    render(<SortieInfo onUpdate={mockOnUpdate} initialData={initialData} />);
+    const input = screen.getByLabelText(/Operating Altitude/i);
+    fireEvent.change(input, { target: { value: "" } });
+    expect(mockOnUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ altitude: [4471, null, 4229] })
+    );
+  });
+});

--- a/src/components/SortieInfo.tsx
+++ b/src/components/SortieInfo.tsx
@@ -19,6 +19,7 @@ type SortieInfoData = Pick<
   | "airport"
   | "route"
   | "weight"
+  | "altitude"
 >;
 
 export default function SortieInfo({ initialData, onUpdate }: SortieInfoProps) {
@@ -31,6 +32,7 @@ export default function SortieInfo({ initialData, onUpdate }: SortieInfoProps) {
     airport: ["", ""],
     route: "",
     weight: null,
+    altitude: [null, null, null],
   });
 
   const [currentTime, setCurrentTime] = useState<Date>(() => new Date());
@@ -85,6 +87,15 @@ export default function SortieInfo({ initialData, onUpdate }: SortieInfoProps) {
     const updatedData = { ...formData, airport: airportArray };
     setFormData(updatedData);
     onUpdate(updatedData);
+  };
+
+  const handleOperatingAltitudeChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value === "" ? null : Number(e.target.value);
+    const currentAltitude = (initialData?.altitude ?? formData.altitude ?? [null, null, null]) as [number | null, number | null, number | null];
+    const newAltitude: [number | null, number | null, number | null] = [currentAltitude[0], value, currentAltitude[2]];
+    const updatedData = { ...formData, altitude: newAltitude };
+    setFormData(updatedData);
+    onUpdate({ altitude: newAltitude });
   };
 
   const utcHourOptions = useMemo(
@@ -260,9 +271,9 @@ export default function SortieInfo({ initialData, onUpdate }: SortieInfoProps) {
           />
         </div>
 
-        <div className="space-y-2 sm:col-span-2">
+        <div className="space-y-2">
           <label htmlFor="route" className="block text-sm font-medium">
-            Area of Operations/Route
+            Area of Operations (position)
           </label>
           <input
             type="text"
@@ -270,6 +281,19 @@ export default function SortieInfo({ initialData, onUpdate }: SortieInfoProps) {
             name="route"
             value={formData.route || ""}
             onChange={handleInputChange}
+            className="w-full px-3 py-2 border rounded-md dark:bg-black/[.15] dark:border-white/[.145]"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <label htmlFor="operatingAltitude" className="block text-sm font-medium">
+            Operating Altitude (MSL ft)
+          </label>
+          <input
+            type="number"
+            id="operatingAltitude"
+            value={formData.altitude?.[1] ?? ""}
+            onChange={handleOperatingAltitudeChange}
             className="w-full px-3 py-2 border rounded-md dark:bg-black/[.15] dark:border-white/[.145]"
           />
         </div>


### PR DESCRIPTION
## Summary

- Moves the **Operating Altitude** input from the Aircraft Performance table into the first section (Sortie Info) so all user-entered fields are in one place
- Renames **"Area of Operations/Route"** → **"Area of Operations (position)"** per reviewer feedback
- Removes `col-span-2` from the route field so it matches the width of other fields
- The operating altitude value still flows through `altitude[1]` in `WorksheetData`, so no calculation logic changes

## Test plan

- [x] All 322 existing tests pass
- [x] New `SortieInfo.test.tsx` with 6 tests covering the operating altitude field (initial value, updates, clearing, preserving departure/arrival values)
- [x] Updated `AircraftPerformance.test.tsx` to reflect the operating altitude is now read-only text in that section

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)