### PR TITLE
Fix #70: Add UTC offset to local time display

### DIFF
--- a/src/components/SortieInfo.tsx
+++ b/src/components/SortieInfo.tsx
@@ -129,7 +129,15 @@ export default function SortieInfo({ initialData, onUpdate }: SortieInfoProps) {
     const localHours = String(sortieUtc.getHours()).padStart(2, "0");
     const localMinutes = String(sortieUtc.getMinutes()).padStart(2, "0");
 
-    const localDisplay = `${localMonth}/${localDay}/${localYear} ${localHours}${localMinutes} local`;
+    const offsetTotalMinutes = -sortieUtc.getTimezoneOffset();
+    const offsetSign = offsetTotalMinutes >= 0 ? "+" : "-";
+    const offsetHours = Math.floor(Math.abs(offsetTotalMinutes) / 60);
+    const offsetMins = Math.abs(offsetTotalMinutes) % 60;
+    const utcOffset = offsetMins === 0
+      ? `UTC${offsetSign}${offsetHours}`
+      : `UTC${offsetSign}${offsetHours}:${String(offsetMins).padStart(2, "0")}`;
+
+    const localDisplay = `${localMonth}/${localDay}/${localYear} ${localHours}${localMinutes} local (${utcOffset})`;
 
     const diffMinutes = Math.round(
       (sortieUtc.getTime() - currentTime.getTime()) / 60000


### PR DESCRIPTION
## Summary
- Adds UTC offset after "local" in the sortie time display
- Format: `MM/DD/YY HHMM local (UTC+7)`, or `(UTC+5:30)` for fractional-hour timezones

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)