### PR TITLE
Add °C/°F temperature display toggle

### DIFF
--- a/src/components/AircraftPerformance.tsx
+++ b/src/components/AircraftPerformance.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import type { WorksheetData } from "@/utils/types";
 import { isApiPopulatedData } from "@/utils/weatherDataMapper";
+import { celciusToFarenheit, farenheitToCelcius } from "@/utils/formulas";
 
 type PerfFields = Pick<
   WorksheetData,
@@ -17,7 +18,8 @@ type PerfFields = Pick<
 interface AircraftPerformanceProps {
   initialData?: PerfFields;
   onUpdate: (data: Partial<WorksheetData>) => void;
-  worksheetData?: Partial<WorksheetData>; // Full worksheet data to check API population
+  worksheetData?: Partial<WorksheetData>;
+  useFahrenheit?: boolean;
 }
 
 const DEFAULT_DATA: PerfFields = {
@@ -36,6 +38,7 @@ export default function AircraftPerformance({
   initialData = DEFAULT_DATA,
   onUpdate,
   worksheetData,
+  useFahrenheit = false,
 }: AircraftPerformanceProps) {
   const [data, setData] = useState<PerfFields>(() => ({
     ...DEFAULT_DATA,
@@ -132,7 +135,14 @@ export default function AircraftPerformance({
   const getValue = (category: keyof PerfFields, index: number): string => {
     const arr = displayData[category];
     const value = arr[index];
-    return value !== null && value !== undefined ? value.toString() : "";
+    if (value === null || value === undefined) return "";
+    if (category === "temp") {
+      if (useFahrenheit) {
+        return Math.round(celciusToFarenheit(value as number)).toString();
+      }
+      return parseFloat((value as number).toFixed(1)).toString();
+    }
+    return value.toString();
   };
 
   // Helper function to get input styling based on API population
@@ -186,7 +196,9 @@ export default function AircraftPerformance({
           number | null,
           number | null
         ];
-        tempArray[index] = newValue as number | null;
+        tempArray[index] = newValue !== null && useFahrenheit
+          ? farenheitToCelcius(newValue)
+          : newValue as number | null;
         newData.temp = tempArray;
         break;
       case "altimeter":
@@ -282,14 +294,14 @@ export default function AircraftPerformance({
               </td>
             </tr>
             <tr className="border-b">
-              <td className="p-2">Temperature (°C)</td>
+              <td className="p-2">Temperature (°{useFahrenheit ? "F" : "C"})</td>
               <td className="p-2">
                 <input
                   type="number"
                   value={getValue("temp", 0)}
                   onChange={(e) => handleInputChange("temp", 0, e.target.value)}
-                  min="-30"
-                  max="55"
+                  min={useFahrenheit ? "-22" : "-30"}
+                  max={useFahrenheit ? "131" : "55"}
                   className={getInputStyling("temp", 0)}
                 />
               </td>
@@ -298,8 +310,8 @@ export default function AircraftPerformance({
                   type="number"
                   value={getValue("temp", 1)}
                   onChange={(e) => handleInputChange("temp", 1, e.target.value)}
-                  min="-30"
-                  max="55"
+                  min={useFahrenheit ? "-22" : "-30"}
+                  max={useFahrenheit ? "131" : "55"}
                   className={getInputStyling("temp", 1)}
                 />
               </td>
@@ -308,8 +320,8 @@ export default function AircraftPerformance({
                   type="number"
                   value={getValue("temp", 2)}
                   onChange={(e) => handleInputChange("temp", 2, e.target.value)}
-                  min="-30"
-                  max="55"
+                  min={useFahrenheit ? "-22" : "-30"}
+                  max={useFahrenheit ? "131" : "55"}
                   className={getInputStyling("temp", 2)}
                 />
               </td>

--- a/src/components/AppContainer.tsx
+++ b/src/components/AppContainer.tsx
@@ -6,6 +6,7 @@ import Calculations from "@/components/Calculations";
 import MountainFlyingChecklist from "@/components/MountainFlyingChecklist";
 import WorksheetHeader from "@/components/WorksheetHeader";
 import { useUrlState } from "@/utils/useUrlState";
+import { useTempUnit } from "@/utils/useTempUnit";
 import type { WorksheetData } from "@/utils/types";
 
 const getDefaultSortieDateTime = () => {
@@ -30,6 +31,7 @@ const getDefaultSortieDateTime = () => {
 
 export default function AppContainer() {
   const defaultSortieDateTime = getDefaultSortieDateTime();
+  const { useFahrenheit, toggleTempUnit } = useTempUnit();
   const [state, setState] = useUrlState({
     // Sortie Information
     pilot: "",
@@ -115,6 +117,8 @@ export default function AppContainer() {
         onWeatherDataUpdate={handleWeatherDataUpdate}
         onWeatherTimestampUpdate={handleWeatherTimestampUpdate}
         weatherLastUpdated={weatherLastUpdated ?? undefined}
+        useFahrenheit={useFahrenheit}
+        onToggleTempUnit={toggleTempUnit}
       />
       <main className="flex-1 w-full flex justify-center px-2 md:px-8 pb-20">
         <div className="w-full max-w-5xl flex flex-col gap-16 items-center">
@@ -122,6 +126,7 @@ export default function AppContainer() {
             state={state}
             onStateUpdate={handleUpdate}
             weatherLastUpdated={weatherLastUpdated ?? undefined}
+            useFahrenheit={useFahrenheit}
           />
           <Calculations state={state} />
           <MountainFlyingChecklist />

--- a/src/components/AppInputs.tsx
+++ b/src/components/AppInputs.tsx
@@ -11,12 +11,14 @@ interface WorksheetFormProps {
   state: WorksheetData;
   onStateUpdate: (updates: Partial<WorksheetData>) => void;
   weatherLastUpdated?: Date;
+  useFahrenheit?: boolean;
 }
 
 export default function AppInputs({
   state,
   onStateUpdate,
   weatherLastUpdated,
+  useFahrenheit,
 }: WorksheetFormProps): ReactNode {
   const handleUpdate = (data: Partial<WorksheetData>) => {
     onStateUpdate(data);
@@ -30,11 +32,13 @@ export default function AppInputs({
         onUpdate={handleUpdate}
         initialData={state}
         lastUpdated={weatherLastUpdated}
+        useFahrenheit={useFahrenheit}
       />
       <AircraftPerformance
         onUpdate={handleUpdate}
         initialData={state}
         worksheetData={state}
+        useFahrenheit={useFahrenheit}
       />
     </div>
   );

--- a/src/components/WeatherInfo.tsx
+++ b/src/components/WeatherInfo.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import type { WorksheetData } from "@/utils/types";
 import { isApiPopulatedData } from "@/utils/weatherDataMapper";
+import { celciusToFarenheit, farenheitToCelcius } from "@/utils/formulas";
 
 type WeatherFields = Pick<
   WorksheetData,
@@ -10,7 +11,8 @@ type WeatherFields = Pick<
 interface WeatherInfoProps {
   initialData?: WorksheetData;
   onUpdate: (data: Partial<WorksheetData>) => void;
-  lastUpdated?: Date; // Timestamp for when data was last updated
+  lastUpdated?: Date;
+  useFahrenheit?: boolean;
 }
 
 const altitudes = ["3,000", "6,000", "9,000", "12,000", "15,000"];
@@ -30,6 +32,7 @@ export default function WeatherInfo({
   initialData,
   onUpdate,
   lastUpdated,
+  useFahrenheit = false,
 }: WeatherInfoProps) {
   const [data, setData] = useState<WeatherFields>(() => ({
     ...DEFAULT_WEATHER_DATA,
@@ -199,17 +202,21 @@ export default function WeatherInfo({
           isValid =
             numValue >= 0 && numValue <= 150 && Number.isInteger(numValue);
           break;
-        case 2: // temp
-          isValid =
-            numValue >= -50 && numValue <= 50 && Number.isInteger(numValue);
+        case 2: { // temp
+          const celsiusValue = useFahrenheit ? farenheitToCelcius(numValue) : numValue;
+          isValid = celsiusValue >= -50 && celsiusValue <= 50;
           break;
+        }
       }
     }
 
     if (isValid) {
       const newWind = [...data.wind] as [(number | null)[], (number | null)[], (number | null)[]];
       newWind[type] = [...newWind[type]];
-      newWind[type][index] = numValue;
+      const storedValue = type === 2 && numValue !== null && useFahrenheit
+        ? farenheitToCelcius(numValue)
+        : numValue;
+      newWind[type][index] = storedValue;
       const newData = {
         ...data,
         wind: newWind,
@@ -306,25 +313,28 @@ export default function WeatherInfo({
             ))}
           </tr>
           <tr>
-            <td className="border p-2">Temperature (°C)</td>
-            {altitudes.map((alt) => (
-              <td key={alt} className="border p-2">
-                <input
-                  type="number"
-                  min={-50}
-                  max={50}
-                  value={displayData.wind?.[2]?.[altitudes.indexOf(alt)] ?? ""}
-                  onChange={(e) =>
-                    handleNumericChange(
-                      2,
-                      altitudes.indexOf(alt),
-                      e.target.value
-                    )
-                  }
-                  className={getInputStyling("temp")}
-                />
-              </td>
-            ))}
+            <td className="border p-2">Temperature (°{useFahrenheit ? "F" : "C"})</td>
+            {altitudes.map((alt) => {
+              const idx = altitudes.indexOf(alt);
+              const rawVal = displayData.wind?.[2]?.[idx];
+              const displayVal = rawVal !== null && rawVal !== undefined
+                ? (useFahrenheit ? Math.round(celciusToFarenheit(rawVal)) : parseFloat(rawVal.toFixed(1)))
+                : "";
+              return (
+                <td key={alt} className="border p-2">
+                  <input
+                    type="number"
+                    min={useFahrenheit ? -58 : -50}
+                    max={useFahrenheit ? 122 : 50}
+                    value={displayVal}
+                    onChange={(e) =>
+                      handleNumericChange(2, idx, e.target.value)
+                    }
+                    className={getInputStyling("temp")}
+                  />
+                </td>
+              );
+            })}
           </tr>
         </tbody>
       </table>

--- a/src/components/WorksheetHeader.tsx
+++ b/src/components/WorksheetHeader.tsx
@@ -13,6 +13,8 @@ interface WorksheetHeaderProps {
   onWeatherDataUpdate: (data: Partial<WorksheetData>) => void;
   onWeatherTimestampUpdate: (timestamp: Date) => void;
   weatherLastUpdated?: Date;
+  useFahrenheit: boolean;
+  onToggleTempUnit: () => void;
 }
 
 const formatUtcDisplay = (date: Date) => {
@@ -87,6 +89,8 @@ export default function WorksheetHeader({
   onWeatherDataUpdate,
   onWeatherTimestampUpdate,
   weatherLastUpdated,
+  useFahrenheit,
+  onToggleTempUnit,
 }: WorksheetHeaderProps) {
   return (
     <header className="w-full bg-slate-900 text-white shadow-md">
@@ -112,6 +116,15 @@ export default function WorksheetHeader({
             >
               <LinkIcon className="h-5 w-5" />
               Copy Link
+            </button>
+            <button
+              onClick={onToggleTempUnit}
+              className="flex items-center gap-1 rounded-md bg-slate-700 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-slate-600"
+              title="Toggle temperature unit"
+            >
+              <span className={useFahrenheit ? "text-slate-400" : "font-bold"}>°C</span>
+              <span className="text-slate-500">|</span>
+              <span className={useFahrenheit ? "font-bold" : "text-slate-400"}>°F</span>
             </button>
             <WeatherDataIntegration
               worksheetData={worksheetData}

--- a/src/utils/useTempUnit.ts
+++ b/src/utils/useTempUnit.ts
@@ -1,0 +1,19 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+export function useTempUnit() {
+  const [useFahrenheit, setUseFahrenheit] = useState(false);
+
+  useEffect(() => {
+    setUseFahrenheit(localStorage.getItem("tempUnit") === "F");
+  }, []);
+
+  const toggleTempUnit = () => {
+    const next = !useFahrenheit;
+    localStorage.setItem("tempUnit", next ? "F" : "C");
+    setUseFahrenheit(next);
+  };
+
+  return { useFahrenheit, toggleTempUnit };
+}


### PR DESCRIPTION
## Summary
- Adds a **°C | °F** toggle button in the worksheet header
- Internal values remain stored in Celsius; conversion is display-only
- User preference is persisted via `localStorage` across page reloads
- Both the Weather Information (wind altitude temps) and Aircraft Performance (departure/operating/arrival temps) sections respond to the toggle
- Celsius display values are rounded to 1 decimal place to handle F→C round-trips cleanly (e.g. 10°F → -12.2°C)

## Test plan
- [ ] Toggle shows °C bold by default; clicking switches to °F bold
- [ ] Temperature labels update to `Temperature (°F)` in both sections
- [ ] Existing Celsius values convert correctly on toggle (e.g. 20°C → 68°F)
- [ ] Typing in °F and toggling back to °C shows rounded value (e.g. 10°F → -12.2°C)
- [ ] API-fetched temperatures (Fetch Weather) display correctly in both units
- [ ] Calculations section (density altitude) is unaffected — uses stored °C values
- [ ] Preference persists after page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)