### PR TITLE
Fix #61: Show '-' for service ceiling when OAT is null

### DIFF
--- a/src/components/ClimbPerformance.test.tsx
+++ b/src/components/ClimbPerformance.test.tsx
@@ -170,4 +170,49 @@ describe("ClimbPerformance Component", () => {
 
     expect(departureCell).toHaveClass("text-right");
   });
+
+  describe("Service Ceiling display", () => {
+    const getServiceCeilingRow = () =>
+      screen.getByText("Service Ceiling (300 ft/min ROC)").closest("tr");
+
+    test("shows '-' for all columns when all OATs are null", () => {
+      render(
+        <ClimbPerformance
+          {...defaultProps}
+          OATs={[null, null, null] as unknown as [number, number, number]}
+        />
+      );
+      const cells = getServiceCeilingRow()?.querySelectorAll("td");
+      expect(cells?.[1]).toHaveTextContent("-");
+      expect(cells?.[2]).toHaveTextContent("-");
+      expect(cells?.[3]).toHaveTextContent("-");
+    });
+
+    test("shows '-' only for operating column when operating OAT is null", () => {
+      render(
+        <ClimbPerformance
+          {...defaultProps}
+          OATs={[20, null, 20] as unknown as [number, number, number]}
+        />
+      );
+      const cells = getServiceCeilingRow()?.querySelectorAll("td");
+      expect(cells?.[1].textContent).toMatch(/ft$/);
+      expect(cells?.[2]).toHaveTextContent("-");
+      expect(cells?.[3].textContent).toMatch(/ft$/);
+    });
+
+    test("shows computed ft values when all OATs are valid numbers", () => {
+      render(<ClimbPerformance {...defaultProps} OATs={[20, 10, 5]} />);
+      const cells = getServiceCeilingRow()?.querySelectorAll("td");
+      expect(cells?.[1].textContent).toMatch(/ft$/);
+      expect(cells?.[2].textContent).toMatch(/ft$/);
+      expect(cells?.[3].textContent).toMatch(/ft$/);
+    });
+
+    test("departure and arrival show the same ceiling for the same OAT", () => {
+      render(<ClimbPerformance {...defaultProps} OATs={[20, null, 20] as unknown as [number, number, number]} />);
+      const cells = getServiceCeilingRow()?.querySelectorAll("td");
+      expect(cells?.[1].textContent).toBe(cells?.[3].textContent);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Fixes service ceiling variance (#61) caused by JavaScript coercing `null` OAT to `0°C` in arithmetic
- Adds `serviceCeilingDisplay()` helper that renders `"-"` when OAT is null/undefined instead of computing with a garbage value
- Adds `Number.isFinite()` guard inside `serviceCeiling()` as a second line of defence
- Adds 4 tests covering null, mixed-null, and valid OAT scenarios

## Root Cause

When weather is fetched for departure/arrival airports, `state.temp[1]` (operating altitude temperature) is intentionally left as `null` — there's no weather station for the operating altitude. Passing `null` to the arithmetic in `findInverseXgivenYandZ` triggered JS numeric coercion (`null → 0`), so the operating column service ceiling was computed as if OAT = 0°C. For a local KOGD flight this meant:

- Departure: ~11,700 ft (at 21°C) ✓
- Operating: ~13,000 ft (null → 0°C) ✗
- Arrival: ~11,700 ft (at 21°C) ✓

The inconsistency between columns — and between runs depending on whether operating temp was set — was the reported variance.

## Test plan

- [ ] All existing ClimbPerformance tests pass
- [ ] New null-OAT tests pass
- [ ] Local KOGD flight: operating column shows `"-"` after fetching weather (no operating temp set)
- [ ] Entering an operating temperature populates the operating column with a computed ft value
- [ ] Departure and arrival show matching ceilings for same-airport flights

🤖 Generated with [Claude Code](https://claude.com/claude-code)