### PR TITLE
Fix #60: Clarify maneuver/canyon speeds are minimums

### DIFF
--- a/src/components/Calculations.test.tsx
+++ b/src/components/Calculations.test.tsx
@@ -178,7 +178,7 @@ describe("Calculations", () => {
     render(<Calculations state={mockWorksheetData} />);
     
     await waitFor(() => {
-      expect(screen.getByText("Maneuver/Canyon Turn Speed (kts) (C182T)")).toBeInTheDocument();
+      expect(screen.getByText("Minimum Maneuver/Canyon Turn Speed (kts) (C182T)")).toBeInTheDocument();
     });
   });
 
@@ -218,7 +218,7 @@ describe("Calculations", () => {
     render(<Calculations state={stateWithUnknownAircraft} />);
     
     // Should render ManeuveringPerformance but with TBD values
-    expect(screen.getByText("Maneuver/Canyon Turn Speed (kts) (UNKNOWN)")).toBeInTheDocument();
+    expect(screen.getByText("Minimum Maneuver/Canyon Turn Speed (kts) (UNKNOWN)")).toBeInTheDocument();
     
     // Should show TBD for all cells since aircraft not found
     const tbdElements = screen.getAllByText("TBD");

--- a/src/components/ManeuveringPerformance.test.tsx
+++ b/src/components/ManeuveringPerformance.test.tsx
@@ -23,7 +23,7 @@ describe("ManeuveringPerformance", () => {
       />
     );
     
-    expect(screen.getByText("Maneuver/Canyon Turn Speed (kts) (C182T)")).toBeInTheDocument();
+    expect(screen.getByText("Minimum Maneuver/Canyon Turn Speed (kts) (C182T)")).toBeInTheDocument();
   });
 
   it("does not render when aircraft model is not provided", () => {

--- a/src/components/ManeuveringPerformance.tsx
+++ b/src/components/ManeuveringPerformance.tsx
@@ -27,7 +27,7 @@ export default function ManeuveringPerformance({
   return (
     <div className="mt-6">
       <h3 className="text-xl font-semibold mb-4">
-        Maneuver/Canyon Turn Speed (kts) ({aircraftModel})
+        Minimum Maneuver/Canyon Turn Speed (kts) ({aircraftModel})
       </h3>
         <table className="min-w-full border-collapse border border-gray-300 dark:border-gray-700">
           <thead>


### PR DESCRIPTION
## Summary
- Adds "Minimum" to the Maneuver/Canyon Turn Speed section title
- Clarifies that displayed speeds are lower bounds based on banked stall speeds (Vso × load factor), not target/desired speeds

Closes #60

🤖 Generated with [Claude Code](https://claude.ai/claude-code)