### PR TITLE
Fix #81: Consistent content width and mobile weather table

### DIFF
--- a/src/components/WeatherInfo.test.tsx
+++ b/src/components/WeatherInfo.test.tsx
@@ -31,19 +31,39 @@ describe("WeatherInfo", () => {
     expect(screen.getByText("Temperature (°C)")).toBeInTheDocument();
   });
 
-  it("renders abbreviated row labels for mobile screens", () => {
+  it("abbreviated row labels carry md:hidden class so they hide on desktop", () => {
     render(<WeatherInfo {...defaultProps} />);
 
-    expect(screen.getByText("Wnd Dir (°)")).toBeInTheDocument();
-    expect(screen.getByText("Wnd Vel (kt)")).toBeInTheDocument();
-    expect(screen.getByText("Temp (°C)")).toBeInTheDocument();
+    expect(screen.getByText("Wnd Dir (°)")).toHaveClass("md:hidden");
+    expect(screen.getByText("Wnd Vel (kt)")).toHaveClass("md:hidden");
+    expect(screen.getByText("Temp (°C)")).toHaveClass("md:hidden");
   });
 
-  it("renders abbreviated temperature label matching useFahrenheit prop", () => {
+  it("full row labels carry hidden and md:inline classes so they show on desktop", () => {
+    render(<WeatherInfo {...defaultProps} />);
+
+    const fullWndDir = screen.getByText("Wind Direction (Degrees)");
+    expect(fullWndDir).toHaveClass("hidden");
+    expect(fullWndDir).toHaveClass("md:inline");
+
+    const fullWndVel = screen.getByText("Wind Velocity (Knots)");
+    expect(fullWndVel).toHaveClass("hidden");
+    expect(fullWndVel).toHaveClass("md:inline");
+
+    const fullTemp = screen.getByText("Temperature (°C)");
+    expect(fullTemp).toHaveClass("hidden");
+    expect(fullTemp).toHaveClass("md:inline");
+  });
+
+  it("abbreviated and full temperature labels reflect useFahrenheit prop", () => {
     render(<WeatherInfo {...defaultProps} useFahrenheit={true} />);
 
-    expect(screen.getByText("Temp (°F)")).toBeInTheDocument();
-    expect(screen.getByText("Temperature (°F)")).toBeInTheDocument();
+    const abbrTemp = screen.getByText("Temp (°F)");
+    expect(abbrTemp).toHaveClass("md:hidden");
+
+    const fullTemp = screen.getByText("Temperature (°F)");
+    expect(fullTemp).toHaveClass("hidden");
+    expect(fullTemp).toHaveClass("md:inline");
   });
 
   it("should show API-populated styling when worksheetData has API data", () => {

--- a/src/components/WeatherInfo.test.tsx
+++ b/src/components/WeatherInfo.test.tsx
@@ -31,6 +31,21 @@ describe("WeatherInfo", () => {
     expect(screen.getByText("Temperature (°C)")).toBeInTheDocument();
   });
 
+  it("renders abbreviated row labels for mobile screens", () => {
+    render(<WeatherInfo {...defaultProps} />);
+
+    expect(screen.getByText("Wnd Dir (°)")).toBeInTheDocument();
+    expect(screen.getByText("Wnd Vel (kt)")).toBeInTheDocument();
+    expect(screen.getByText("Temp (°C)")).toBeInTheDocument();
+  });
+
+  it("renders abbreviated temperature label matching useFahrenheit prop", () => {
+    render(<WeatherInfo {...defaultProps} useFahrenheit={true} />);
+
+    expect(screen.getByText("Temp (°F)")).toBeInTheDocument();
+    expect(screen.getByText("Temperature (°F)")).toBeInTheDocument();
+  });
+
   it("should show API-populated styling when worksheetData has API data", () => {
     const worksheetDataWithApi: WorksheetData = {
       ...defaultProps.initialData,

--- a/src/components/WeatherInfo.tsx
+++ b/src/components/WeatherInfo.tsx
@@ -258,6 +258,7 @@ export default function WeatherInfo({
           winds
         </a>
       </p>
+      <div className="overflow-x-auto">
       <table className="w-full border-collapse">
         <thead>
           <tr className="bg-gray-100 dark:bg-gray-800">
@@ -271,7 +272,10 @@ export default function WeatherInfo({
         </thead>
         <tbody>
           <tr>
-            <td className="border p-2">Wind Direction (Degrees)</td>
+            <td className="border p-2">
+              <span className="hidden md:inline">Wind Direction (Degrees)</span>
+              <span className="md:hidden">Wnd Dir (°)</span>
+            </td>
             {altitudes.map((alt) => (
               <td key={alt} className="border p-2">
                 <input
@@ -292,7 +296,10 @@ export default function WeatherInfo({
             ))}
           </tr>
           <tr>
-            <td className="border p-2">Wind Velocity (Knots)</td>
+            <td className="border p-2">
+              <span className="hidden md:inline">Wind Velocity (Knots)</span>
+              <span className="md:hidden">Wnd Vel (kt)</span>
+            </td>
             {altitudes.map((alt) => (
               <td key={alt} className="border p-2">
                 <input
@@ -313,7 +320,10 @@ export default function WeatherInfo({
             ))}
           </tr>
           <tr>
-            <td className="border p-2">Temperature (°{useFahrenheit ? "F" : "C"})</td>
+            <td className="border p-2">
+              <span className="hidden md:inline">Temperature (°{useFahrenheit ? "F" : "C"})</span>
+              <span className="md:hidden">Temp (°{useFahrenheit ? "F" : "C"})</span>
+            </td>
             {altitudes.map((alt) => {
               const idx = altitudes.indexOf(alt);
               const rawVal = displayData.wind?.[2]?.[idx];
@@ -338,6 +348,7 @@ export default function WeatherInfo({
           </tr>
         </tbody>
       </table>
+      </div>
 
       <div className="mt-4 space-y-2">
         <div className="flex items-center gap-2">

--- a/src/components/WorksheetHeader.test.tsx
+++ b/src/components/WorksheetHeader.test.tsx
@@ -21,4 +21,19 @@ describe("WorksheetHeader", () => {
     expect(screen.getByText("Current Time")).toBeInTheDocument();
     expect(screen.queryByText("Current UTC")).not.toBeInTheDocument();
   });
+
+  it("header inner container uses max-w-5xl consistent with main content width", () => {
+    const { container } = render(
+      <WorksheetHeader
+        onReset={jest.fn()}
+        onShare={jest.fn()}
+        worksheetData={{}}
+        onWeatherDataUpdate={jest.fn()}
+        onWeatherTimestampUpdate={jest.fn()}
+      />
+    );
+
+    expect(container.querySelector(".max-w-6xl")).not.toBeInTheDocument();
+    expect(container.querySelector(".max-w-5xl")).toBeInTheDocument();
+  });
 });

--- a/src/components/WorksheetHeader.test.tsx
+++ b/src/components/WorksheetHeader.test.tsx
@@ -6,34 +6,29 @@ jest.mock("./WeatherDataIntegration", () => ({
   default: () => null,
 }));
 
+const defaultProps = {
+  onReset: jest.fn(),
+  onShare: jest.fn(),
+  worksheetData: {},
+  onWeatherDataUpdate: jest.fn(),
+  onWeatherTimestampUpdate: jest.fn(),
+  useFahrenheit: false,
+  onToggleTempUnit: jest.fn(),
+};
+
 describe("WorksheetHeader", () => {
   it('renders "Current Time" instead of "Current UTC"', () => {
-    render(
-      <WorksheetHeader
-        onReset={jest.fn()}
-        onShare={jest.fn()}
-        worksheetData={{}}
-        onWeatherDataUpdate={jest.fn()}
-        onWeatherTimestampUpdate={jest.fn()}
-      />
-    );
+    render(<WorksheetHeader {...defaultProps} />);
 
     expect(screen.getByText("Current Time")).toBeInTheDocument();
     expect(screen.queryByText("Current UTC")).not.toBeInTheDocument();
   });
 
   it("header inner container uses max-w-5xl consistent with main content width", () => {
-    const { container } = render(
-      <WorksheetHeader
-        onReset={jest.fn()}
-        onShare={jest.fn()}
-        worksheetData={{}}
-        onWeatherDataUpdate={jest.fn()}
-        onWeatherTimestampUpdate={jest.fn()}
-      />
-    );
+    render(<WorksheetHeader {...defaultProps} />);
 
-    expect(container.querySelector(".max-w-6xl")).not.toBeInTheDocument();
-    expect(container.querySelector(".max-w-5xl")).toBeInTheDocument();
+    const banner = screen.getByRole("banner");
+    expect(banner.querySelector(".max-w-6xl")).not.toBeInTheDocument();
+    expect(banner.querySelector(".max-w-5xl")).toBeInTheDocument();
   });
 });

--- a/src/components/WorksheetHeader.tsx
+++ b/src/components/WorksheetHeader.tsx
@@ -94,7 +94,7 @@ export default function WorksheetHeader({
 }: WorksheetHeaderProps) {
   return (
     <header className="w-full bg-slate-900 text-white shadow-md">
-      <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-4 py-4 md:px-6">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-4 px-4 py-4 md:px-6">
         <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
           <h1 className="text-3xl font-bold tracking-tight">
             Mountain Flying Worksheet


### PR DESCRIPTION
## Summary
- Align header inner container from `max-w-6xl` to `max-w-5xl` so the header no longer bleeds wider than the page content on desktop
- Add responsive abbreviated row labels in the weather table (`Wnd Dir (°)`, `Wnd Vel (kt)`, `Temp (°C/°F)`) visible on mobile; full labels remain on `md+` screens
- Wrap weather table in `overflow-x-auto` as a safety net for very narrow viewports

Closes #81

## Test Plan
- [ ] Desktop: header width matches content width (no wider bleed at the sides)
- [ ] Mobile: weather table row labels show abbreviated form and table fits within viewport
- [ ] `md+` screens: full row labels still display as before
- [ ] All 330 tests pass: `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)