### PR TITLE
Fix #62: Show MSL service ceiling with PA/DA hover tooltip

### DIFF
--- a/src/components/Calculations.tsx
+++ b/src/components/Calculations.tsx
@@ -291,6 +291,7 @@ export default function Calculations({ state }: CalculationsProps) {
           weight={state.weight}
           OATs={state.temp}
           PAs={PAs}
+          altimeters={state.altimeter}
         />
         <TOLDErrorBoundary
           onError={(error, errorInfo) => {

--- a/src/components/ClimbPerformance.test.tsx
+++ b/src/components/ClimbPerformance.test.tsx
@@ -173,7 +173,12 @@ describe("ClimbPerformance Component", () => {
 
   describe("Service Ceiling display", () => {
     const getServiceCeilingRow = () =>
-      screen.getByText("Service Ceiling (300 ft/min ROC)").closest("tr");
+      screen.getByText(/Service Ceiling \(300 ft\/min ROC, MSL\)/).closest("tr");
+
+    test("label reads 'Service Ceiling (300 ft/min ROC, MSL)'", () => {
+      render(<ClimbPerformance {...defaultProps} />);
+      expect(screen.getByText("Service Ceiling (300 ft/min ROC, MSL)")).toBeInTheDocument();
+    });
 
     test("shows '-' for all columns when all OATs are null", () => {
       render(
@@ -188,29 +193,81 @@ describe("ClimbPerformance Component", () => {
       expect(cells?.[3]).toHaveTextContent("-");
     });
 
-    test("shows '-' only for operating column when operating OAT is null", () => {
+    test("shows PA with '(PA)' suffix when altimeter is null", () => {
       render(
         <ClimbPerformance
           {...defaultProps}
           OATs={[20, null, 20] as unknown as [number, number, number]}
+          altimeters={[null, null, null]}
+        />
+      );
+      const cells = getServiceCeilingRow()?.querySelectorAll("td");
+      expect(cells?.[1].textContent).toMatch(/ft \(PA\)$/);
+      expect(cells?.[2]).toHaveTextContent("-");
+      expect(cells?.[3].textContent).toMatch(/ft \(PA\)$/);
+    });
+
+    test("shows MSL without '(PA)' suffix when altimeter is provided", () => {
+      render(
+        <ClimbPerformance
+          {...defaultProps}
+          OATs={[20, null, 20] as unknown as [number, number, number]}
+          altimeters={[29.92, null, 29.92]}
         />
       );
       const cells = getServiceCeilingRow()?.querySelectorAll("td");
       expect(cells?.[1].textContent).toMatch(/ft$/);
-      expect(cells?.[2]).toHaveTextContent("-");
+      expect(cells?.[1].textContent).not.toMatch(/\(PA\)/);
       expect(cells?.[3].textContent).toMatch(/ft$/);
+      expect(cells?.[3].textContent).not.toMatch(/\(PA\)/);
     });
 
-    test("shows computed ft values when all OATs are valid numbers", () => {
-      render(<ClimbPerformance {...defaultProps} OATs={[20, 10, 5]} />);
+    test("MSL is 1000 ft higher than PA when altimeter is 30.92", () => {
+      const { rerender } = render(
+        <ClimbPerformance
+          {...defaultProps}
+          OATs={[20, null, null] as unknown as [number, number, number]}
+          altimeters={[29.92, null, null]}
+        />
+      );
+      const baseRow = getServiceCeilingRow();
+      const baseMSL = parseInt(baseRow?.querySelectorAll("td")?.[1].textContent?.replace(/[^0-9]/g, "") ?? "0");
+
+      rerender(
+        <ClimbPerformance
+          {...defaultProps}
+          OATs={[20, null, null] as unknown as [number, number, number]}
+          altimeters={[30.92, null, null]}
+        />
+      );
+      const highRow = getServiceCeilingRow();
+      const highMSL = parseInt(highRow?.querySelectorAll("td")?.[1].textContent?.replace(/[^0-9]/g, "") ?? "0");
+
+      expect(highMSL - baseMSL).toBe(1000);
+    });
+
+    test("cell has title attribute with Pressure Alt and Density Alt when value is computed", () => {
+      render(
+        <ClimbPerformance
+          {...defaultProps}
+          OATs={[20, null, null] as unknown as [number, number, number]}
+          altimeters={[29.92, null, null]}
+        />
+      );
       const cells = getServiceCeilingRow()?.querySelectorAll("td");
-      expect(cells?.[1].textContent).toMatch(/ft$/);
-      expect(cells?.[2].textContent).toMatch(/ft$/);
-      expect(cells?.[3].textContent).toMatch(/ft$/);
+      const title = cells?.[1].getAttribute("title") ?? "";
+      expect(title).toMatch(/Pressure Alt:/);
+      expect(title).toMatch(/Density Alt:/);
     });
 
-    test("departure and arrival show the same ceiling for the same OAT", () => {
-      render(<ClimbPerformance {...defaultProps} OATs={[20, null, 20] as unknown as [number, number, number]} />);
+    test("departure and arrival show the same MSL ceiling for the same OAT and altimeter", () => {
+      render(
+        <ClimbPerformance
+          {...defaultProps}
+          OATs={[20, null, 20] as unknown as [number, number, number]}
+          altimeters={[29.92, null, 29.92]}
+        />
+      );
       const cells = getServiceCeilingRow()?.querySelectorAll("td");
       expect(cells?.[1].textContent).toBe(cells?.[3].textContent);
     });

--- a/src/components/ClimbPerformance.test.tsx
+++ b/src/components/ClimbPerformance.test.tsx
@@ -260,6 +260,18 @@ describe("ClimbPerformance Component", () => {
       expect(title).toMatch(/Density Alt:/);
     });
 
+    test("shows PA with '(PA)' suffix when altimeter is -1 sentinel", () => {
+      render(
+        <ClimbPerformance
+          {...defaultProps}
+          OATs={[20, null, null] as unknown as [number, number, number]}
+          altimeters={[-1, null, null]}
+        />
+      );
+      const cells = getServiceCeilingRow()?.querySelectorAll("td");
+      expect(cells?.[1].textContent).toMatch(/ft \(PA\)$/);
+    });
+
     test("departure and arrival show the same MSL ceiling for the same OAT and altimeter", () => {
       render(
         <ClimbPerformance

--- a/src/components/ClimbPerformance.tsx
+++ b/src/components/ClimbPerformance.tsx
@@ -225,7 +225,7 @@ export default function ClimbPerformance({
                 const titleText = scDA !== null
                   ? `Pressure Alt: ${scPARounded.toLocaleString()} ft\nDensity Alt: ${scDA.toLocaleString()} ft`
                   : `Pressure Alt: ${scPARounded.toLocaleString()} ft`;
-                const displayValue = altimeter !== null
+                const displayValue = altimeter !== null && altimeter >= 28
                   ? `${Math.round(scPA + (altimeter - 29.92) * 1000).toLocaleString()} ft`
                   : `${scPARounded.toLocaleString()} ft (PA)`;
                 return (

--- a/src/components/ClimbPerformance.tsx
+++ b/src/components/ClimbPerformance.tsx
@@ -6,7 +6,7 @@ import {
   findInverseXgivenYandZ,
   FlexibleInterpolationTable,
 } from "@/utils/interpolation";
-import { calculateVra, calculateVx } from "@/utils/formulas";
+import { calculateVra, calculateVx, pressureAltitudeToDensityAltitude } from "@/utils/formulas";
 import { Aircraft } from "@/utils/types";
 
 interface ClimbPerformanceProps {
@@ -14,6 +14,7 @@ interface ClimbPerformanceProps {
   weight?: number | null;
   OATs?: [number | null, number | null, number | null];
   PAs?: [number | null, number | null, number | null];
+  altimeters?: [number | null, number | null, number | null];
 }
 
 export default function ClimbPerformance({
@@ -21,6 +22,7 @@ export default function ClimbPerformance({
   weight,
   OATs,
   PAs,
+  altimeters,
 }: ClimbPerformanceProps) {
   const [ratesOfClimb, setRatesOfClimb] = useState<[number | null, number | null, number | null]>([
     null, null, null,
@@ -210,12 +212,25 @@ export default function ClimbPerformance({
               <td className="py-2 px-4 text-right"></td>
             </tr>
             <tr className="border-b dark:border-gray-700">
-              <td className="py-2 px-4">Service Ceiling (300 ft/min ROC)</td>
+              <td className="py-2 px-4">Service Ceiling (300 ft/min ROC, MSL)</td>
               {([0, 1, 2] as const).map((i) => {
-                const sc = serviceCeiling(OATs?.[i] ?? null);
+                const scPA = serviceCeiling(OATs?.[i] ?? null);
+                if (scPA === null) {
+                  return <td key={i} className="py-2 px-4 text-right">-</td>;
+                }
+                const oat = OATs?.[i] ?? null;
+                const altimeter = altimeters?.[i] ?? null;
+                const scPARounded = Math.round(scPA);
+                const scDA = oat !== null ? Math.round(pressureAltitudeToDensityAltitude(scPA, oat)) : null;
+                const titleText = scDA !== null
+                  ? `Pressure Alt: ${scPARounded.toLocaleString()} ft\nDensity Alt: ${scDA.toLocaleString()} ft`
+                  : `Pressure Alt: ${scPARounded.toLocaleString()} ft`;
+                const displayValue = altimeter !== null
+                  ? `${Math.round(scPA + (altimeter - 29.92) * 1000).toLocaleString()} ft`
+                  : `${scPARounded.toLocaleString()} ft (PA)`;
                 return (
-                  <td key={i} className="py-2 px-4 text-right">
-                    {sc !== null ? `${Math.round(sc).toLocaleString()} ft` : "-"}
+                  <td key={i} className="py-2 px-4 text-right" title={titleText}>
+                    {displayValue}
                   </td>
                 );
               })}


### PR DESCRIPTION
## Summary
- Updates service ceiling label to **"Service Ceiling (300 ft/min ROC, MSL)"** per #62
- Converts the calculated Pressure Altitude (PA) to MSL using the altimeter setting for each location; falls back to `X ft (PA)` when altimeter is unavailable
- Adds a `title` hover tooltip on each service ceiling cell showing `Pressure Alt: X ft\nDensity Alt: Y ft`

## Details
The calculation remains PA-based (interpolating climb performance data indexed by pressure altitude until ROC = 300 ft/min). The displayed value is converted to MSL via `PA + (altimeter - 29.92) × 1000`. Density altitude in the tooltip uses the existing `pressureAltitudeToDensityAltitude` utility with the location OAT.

## Test Plan
- [ ] Load the worksheet with weather data — service ceiling row shows MSL values (no `(PA)` suffix)
- [ ] Clear altimeter setting for one location — that cell shows `X ft (PA)` fallback
- [ ] Hover over a service ceiling cell — tooltip shows `Pressure Alt: X ft` and `Density Alt: Y ft`
- [ ] All 334 tests pass: `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)