### PR TITLE
Fix #63: correct service ceiling extrapolation and T182T ceiling value

### DIFF
--- a/src/components/ClimbPerformance.test.tsx
+++ b/src/components/ClimbPerformance.test.tsx
@@ -20,13 +20,14 @@ jest.mock("../data/aircraft.json", () => [
       Vso: [51, 41],
     },
     climbPerformance: {
-      pressureAltitudes: [0, 2000, 4000],
-      climbSpeeds: [80, 79, 78],
+      pressureAltitudes: [0, 2000, 4000, 6000],
+      climbSpeeds: [80, 79, 78, 77],
       temperatures: [-20, 0, 20],
       data: [
         [1055, 980, 905],
         [945, 875, 805],
         [840, 770, 705],
+        [400, 350, 280], // drops below 300 fpm at 20°C; at -20°C still 400 fpm (exceeds table)
       ],
     },
     Vx: {
@@ -270,6 +271,21 @@ describe("ClimbPerformance Component", () => {
       );
       const cells = getServiceCeilingRow()?.querySelectorAll("td");
       expect(cells?.[1].textContent).toMatch(/ft \(PA\)$/);
+    });
+
+    test("shows '> X ft' when 300 fpm ROC is never reached within the table", () => {
+      // At -20°C the mock data tops out at 6,000 ft with 400 fpm — ceiling exceeds the table.
+      // Display "> 6,000 ft" rather than an unreliable extrapolated altitude.
+      render(
+        <ClimbPerformance
+          {...defaultProps}
+          OATs={[-20, -20, -20]}
+        />
+      );
+      const cells = getServiceCeilingRow()?.querySelectorAll("td");
+      expect(cells?.[1].textContent).toBe("> 6,000 ft");
+      expect(cells?.[2].textContent).toBe("> 6,000 ft");
+      expect(cells?.[3].textContent).toBe("> 6,000 ft");
     });
 
     test("departure and arrival show the same MSL ceiling for the same OAT and altimeter", () => {

--- a/src/components/ClimbPerformance.tsx
+++ b/src/components/ClimbPerformance.tsx
@@ -126,16 +126,18 @@ export default function ClimbPerformance({
     return calculateVx(aircraft, pa);
   };
 
-  const serviceCeiling = (oat: number | null): number | null => {
+  const serviceCeiling = (oat: number | null): number | "exceeds_table" | null => {
     if (oat === null || !aircraft) return null;
     try {
-      return findInverseXgivenYandZ(
+      const alts = aircraft.climbPerformance.pressureAltitudes;
+      const computed = findInverseXgivenYandZ(
         aircraft.climbPerformance.data,
-        aircraft.climbPerformance.pressureAltitudes,
+        alts,
         aircraft.climbPerformance.temperatures,
         300,
         oat
       );
+      return computed > alts[alts.length - 1] ? "exceeds_table" : computed;
     } catch {
       return null;
     }
@@ -214,19 +216,28 @@ export default function ClimbPerformance({
             <tr className="border-b dark:border-gray-700">
               <td className="py-2 px-4">Service Ceiling (300 ft/min ROC, MSL)</td>
               {([0, 1, 2] as const).map((i) => {
-                const scPA = serviceCeiling(OATs?.[i] ?? null);
-                if (scPA === null) {
+                const sc = serviceCeiling(OATs?.[i] ?? null);
+                if (sc === null) {
                   return <td key={i} className="py-2 px-4 text-right">-</td>;
+                }
+                const alts = aircraft?.climbPerformance.pressureAltitudes;
+                const maxTableAlt = alts ? alts[alts.length - 1] : null;
+                if (sc === "exceeds_table") {
+                  return (
+                    <td key={i} className="py-2 px-4 text-right">
+                      {`> ${maxTableAlt?.toLocaleString()} ft`}
+                    </td>
+                  );
                 }
                 const oat = OATs?.[i] ?? null;
                 const altimeter = altimeters?.[i] ?? null;
-                const scPARounded = Math.round(scPA);
-                const scDA = oat !== null ? Math.round(pressureAltitudeToDensityAltitude(scPA, oat)) : null;
+                const scPARounded = Math.round(sc);
+                const scDA = oat !== null ? Math.round(pressureAltitudeToDensityAltitude(sc, oat)) : null;
                 const titleText = scDA !== null
                   ? `Pressure Alt: ${scPARounded.toLocaleString()} ft\nDensity Alt: ${scDA.toLocaleString()} ft`
                   : `Pressure Alt: ${scPARounded.toLocaleString()} ft`;
                 const displayValue = altimeter !== null && altimeter >= 28
-                  ? `${Math.round(scPA + (altimeter - 29.92) * 1000).toLocaleString()} ft`
+                  ? `${Math.round(sc + (altimeter - 29.92) * 1000).toLocaleString()} ft`
                   : `${scPARounded.toLocaleString()} ft (PA)`;
                 return (
                   <td key={i} className="py-2 px-4 text-right" title={titleText}>

--- a/src/data/aircraft.json
+++ b/src/data/aircraft.json
@@ -293,7 +293,7 @@
     "maxGrossWeight": 3100,
     "fuelCapacity": 87,
     "fuelWeightPerGallon": 6,
-    "serviceCeiling": 12000,
+    "serviceCeiling": 20000,
     "maneuvering": {
       "weights": [2100, 2600, 3100],
       "Va": [91, 101, 110]

--- a/src/utils/__tests__/interpolation.test.ts
+++ b/src/utils/__tests__/interpolation.test.ts
@@ -272,6 +272,33 @@ describe("Interpolation Functions", () => {
         findInverseXgivenYandZ(dataAllNulls, xAxisAllNulls, yAxisAllNulls, 500, 30);
       }).toThrow("all data points are null");
     });
+
+    describe("extrapolation direction in non-linear decreasing series", () => {
+      // Data that is NOT collinear: steep drop early, then levels off.
+      // This is the real-world pattern for aircraft climb rates (ROC drops faster at low altitude).
+      // Only non-linear data exposes the bug: with linear data, both ends extrapolate identically.
+      const xAxisNL = [0, 5000, 10000, 15000];
+      const yAxisNL = [0];
+      const dataNL = [[800], [500], [400], [350]]; // steep early drop, then leveling off
+
+      it("extrapolates beyond max altitude from last two points when target is below all values", () => {
+        // Target 100 fpm is below the minimum (350 fpm at 15000 ft).
+        // Service ceiling is above the table — must extrapolate from the TOP of the data (last two points).
+        // last two: x=10000 (z=400) and x=15000 (z=350)
+        // t = (100 - 400) / (350 - 400) = 6.0  →  result = 10000 + 6×5000 = 40000 ft
+        const result = findInverseXgivenYandZ(dataNL, xAxisNL, yAxisNL, 100, 0);
+        expect(result).toBeCloseTo(40000, -2);
+      });
+
+      it("extrapolates below min altitude from first two points when target is above all values", () => {
+        // Target 1000 fpm is above the maximum (800 fpm at 0 ft).
+        // Service ceiling is below the table — must extrapolate from the BOTTOM of the data (first two points).
+        // first two: x=0 (z=800) and x=5000 (z=500)
+        // t = (1000 - 800) / (500 - 800) ≈ -0.6667  →  result = 0 + (-0.6667)×5000 ≈ -3333 ft
+        const result = findInverseXgivenYandZ(dataNL, xAxisNL, yAxisNL, 1000, 0);
+        expect(result).toBeCloseTo(-3333, -2);
+      });
+    });
   });
 
   describe("createInterpolationTable", () => {

--- a/src/utils/__tests__/interpolation.test.ts
+++ b/src/utils/__tests__/interpolation.test.ts
@@ -281,18 +281,18 @@ describe("Interpolation Functions", () => {
       const yAxisNL = [0];
       const dataNL = [[800], [500], [400], [350]]; // steep early drop, then leveling off
 
-      it("extrapolates beyond max altitude from last two points when target is below all values", () => {
+      it("extrapolates from the end closer to the target when target is below all values", () => {
         // Target 100 fpm is below the minimum (350 fpm at 15000 ft).
-        // Service ceiling is above the table — must extrapolate from the TOP of the data (last two points).
+        // lastZ=350 is closer to 100 than firstZ=800, so extrapolate from the last two points.
         // last two: x=10000 (z=400) and x=15000 (z=350)
         // t = (100 - 400) / (350 - 400) = 6.0  →  result = 10000 + 6×5000 = 40000 ft
         const result = findInverseXgivenYandZ(dataNL, xAxisNL, yAxisNL, 100, 0);
         expect(result).toBeCloseTo(40000, -2);
       });
 
-      it("extrapolates below min altitude from first two points when target is above all values", () => {
+      it("extrapolates from the end closer to the target when target is above all values", () => {
         // Target 1000 fpm is above the maximum (800 fpm at 0 ft).
-        // Service ceiling is below the table — must extrapolate from the BOTTOM of the data (first two points).
+        // firstZ=800 is closer to 1000 than lastZ=350, so extrapolate from the first two points.
         // first two: x=0 (z=800) and x=5000 (z=500)
         // t = (1000 - 800) / (500 - 800) ≈ -0.6667  →  result = 0 + (-0.6667)×5000 ≈ -3333 ft
         const result = findInverseXgivenYandZ(dataNL, xAxisNL, yAxisNL, 1000, 0);

--- a/src/utils/interpolation.ts
+++ b/src/utils/interpolation.ts
@@ -386,19 +386,21 @@ export function findInverseXgivenYandZ(
     return validXAxis[0];
   }
 
-  if (targetZ < Math.min(firstZ, lastZ)) {
-    // Target is beyond the high-X end of the data (e.g. service ceiling above max table altitude).
-    // For a decreasing series (ROC drops with altitude), extrapolate from the last two points.
-    const last = validXAxis.length - 1;
-    const t =
-      (targetZ - zValuesAtY[last - 1]) /
-      (zValuesAtY[last] - zValuesAtY[last - 1]);
-    return validXAxis[last - 1] + t * (validXAxis[last] - validXAxis[last - 1]);
-  } else if (targetZ > Math.max(firstZ, lastZ)) {
-    // Target is beyond the low-X end of the data (e.g. service ceiling below min table altitude).
-    // For a decreasing series, extrapolate from the first two points.
-    const t = (targetZ - zValuesAtY[0]) / (zValuesAtY[1] - zValuesAtY[0]);
-    return validXAxis[0] + t * (validXAxis[1] - validXAxis[0]);
+  if (targetZ < Math.min(firstZ, lastZ) || targetZ > Math.max(firstZ, lastZ)) {
+    // Target is outside the data range — extrapolate from whichever end has a Z value
+    // closer to the target. This correctly handles both decreasing series (ROC vs altitude)
+    // and increasing series without assuming a particular direction.
+    const useLastTwoPoints = Math.abs(lastZ - targetZ) < Math.abs(firstZ - targetZ);
+    if (useLastTwoPoints) {
+      const last = validXAxis.length - 1;
+      const t =
+        (targetZ - zValuesAtY[last - 1]) /
+        (zValuesAtY[last] - zValuesAtY[last - 1]);
+      return validXAxis[last - 1] + t * (validXAxis[last] - validXAxis[last - 1]);
+    } else {
+      const t = (targetZ - zValuesAtY[0]) / (zValuesAtY[1] - zValuesAtY[0]);
+      return validXAxis[0] + t * (validXAxis[1] - validXAxis[0]);
+    }
   } else {
     // This should never happen if the data is properly sorted
     throw new Error("Could not find matching climb rate");

--- a/src/utils/interpolation.ts
+++ b/src/utils/interpolation.ts
@@ -382,25 +382,23 @@ export function findInverseXgivenYandZ(
   const firstZ = zValuesAtY[0];
   const lastZ = zValuesAtY[zValuesAtY.length - 1];
 
+  if (validXAxis.length < 2) {
+    return validXAxis[0];
+  }
+
   if (targetZ < Math.min(firstZ, lastZ)) {
-    // Target is below the data range, extrapolate using first two points
-    if (validXAxis.length < 2) {
-      // Not enough points for extrapolation
-      return validXAxis[0];
-    }
-    const t = (targetZ - zValuesAtY[0]) / (zValuesAtY[1] - zValuesAtY[0]);
-    return validXAxis[0] + t * (validXAxis[1] - validXAxis[0]);
-  } else if (targetZ > Math.max(firstZ, lastZ)) {
-    // Target is above the data range, extrapolate using last two points
-    if (validXAxis.length < 2) {
-      // Not enough points for extrapolation
-      return validXAxis[0];
-    }
+    // Target is beyond the high-X end of the data (e.g. service ceiling above max table altitude).
+    // For a decreasing series (ROC drops with altitude), extrapolate from the last two points.
     const last = validXAxis.length - 1;
     const t =
       (targetZ - zValuesAtY[last - 1]) /
       (zValuesAtY[last] - zValuesAtY[last - 1]);
     return validXAxis[last - 1] + t * (validXAxis[last] - validXAxis[last - 1]);
+  } else if (targetZ > Math.max(firstZ, lastZ)) {
+    // Target is beyond the low-X end of the data (e.g. service ceiling below min table altitude).
+    // For a decreasing series, extrapolate from the first two points.
+    const t = (targetZ - zValuesAtY[0]) / (zValuesAtY[1] - zValuesAtY[0]);
+    return validXAxis[0] + t * (validXAxis[1] - validXAxis[0]);
   } else {
     // This should never happen if the data is properly sorted
     throw new Error("Could not find matching climb rate");


### PR DESCRIPTION
## Summary
- Fixes a swapped-branch bug in \`findInverseXgivenYandZ\` that caused the T182T (and any aircraft whose climb table never reaches 300 fpm) to show an absurd service ceiling (~43,000 ft at -20°C)
- Corrects T182T \`serviceCeiling\` from 12,000 ft to 20,000 ft — the turbocharged aircraft's actual POH ceiling
- When ROC never drops to 300 fpm within the climb table (ceiling is beyond the table's altitude range), displays \`> 20,000 ft\` instead of an unreliable extrapolated number
- Makes extrapolation direction work for both increasing and decreasing ROC series by using the endpoint whose Z value is closer to the target
- Adds regression tests with non-linear data that expose the extrapolation direction bug

## Root Cause
\`findInverseXgivenYandZ\` had the extrapolation branch bodies swapped. When ROC falls below all table values (service ceiling is above max table altitude), it used the first two data points — producing a wildly wrong result. The fix selects the extrapolation endpoint based on which end of the data is closer to the target value, which correctly handles both increasing and decreasing series.

## Display Behavior
- Ceiling within the table: shows MSL altitude with PA/DA hover tooltip (e.g. \`5,906 ft\`)
- Ceiling beyond the table's max altitude: shows \`> 20,000 ft\` — the T182T case, since its table stays above 300 fpm all the way to 20,000 ft

## Test Plan
- [x] Select T182T — service ceiling shows \`> 20,000 ft\` for all locations
- [x] Select C182T at warm OAT — service ceiling shows a specific altitude (ceiling is within the table)
- [x] Hover over a service ceiling cell with a numeric value — tooltip shows \`Pressure Alt\` and \`Density Alt\`
- [ ] All 344 tests pass: \`npm test\`

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)