### PR TITLE
Fix #65: correct T206H Vso for accurate Vra and canyon turn speeds

### DIFF
--- a/src/data/aircraft.json
+++ b/src/data/aircraft.json
@@ -451,7 +451,7 @@
     },
     "stallSpeeds": {
       "flaps": [0, 30],
-      "Vso": [59, 47]
+      "Vso": [63, 47]
     },
     "climbPerformance": {
       "pressureAltitudes": [


### PR DESCRIPTION
## Summary
- Corrects T206H `stallSpeeds.Vso[0]` from 59 to 63 KIAS — the most-forward-CG flaps-up stall speed at max gross weight (POH page 5-17, Figure 5-4)
- Fixes Vra display: 59 × 1.7 = 100 kts → 63 × 1.7 = **107 kts** ✓
- Fixes canyon turn 60° bank speed: 59 × 1.4 = 83 kts → 63 × 1.4 = **88 kts** ✓

## Root Cause
The previous value of 59 KIAS was the most-rearward-CG stall speed. For safety calculations (Vra and maneuvering speeds), the POH's most-forward-CG value (63 KIAS) is the correct conservative figure.

**Not data bugs (confirmed correct per POH):**
- Vx `[89, 89, 79]` at `[0, 17000, 24000]` ft — POH states "89 KIAS constant from SL to 17,000 ft"
- Va `[106, 120, 125]` KIAS at weights `[2300, 2950, 3600]` lbs — matches POH Figure 2-1 exactly

## Test Plan
- [x] All 344 unit tests pass
- [ ] Verify T206H worksheet shows Vra = 107 kts at typical operating weight
- [ ] Verify T206H canyon turn table shows 88 kts at 60° bank, flaps 0°

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)