### PR TITLE
Add intelligent position parsing for area of operations (#90)

### DIFF
--- a/docs/superpowers/plans/2026-05-09-position-intelligence.md
+++ b/docs/superpowers/plans/2026-05-09-position-intelligence.md
@@ -1,0 +1,1784 @@
+# Position Intelligence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add ForeFlight-style position parsing to the "Area of Operations" field in the sortie form, supporting eight input formats (decimal, DMS, DDM with letter or minus polarity, plus airport ID/radial/distance and VOR ID/radial/distance), resolving them to canonical decimal-degree coordinates.
+
+**Architecture:** A pure synchronous parser yields a discriminated union per input. Coordinate kinds resolve immediately; radial-distance kinds trigger an aviationweather.gov lookup, then run a spherical-geodesic destination calculation with magnetic variation applied via the `geomagnetism` npm package (World Magnetic Model). A new `PositionInput` component encapsulates the input/lookup state machine and replaces the inline `<input id="route">` in `SortieInfo`. URL state caches the resolved `[lat, lon]` so reloaded URLs do not re-fetch.
+
+**Tech Stack:** TypeScript, React 19, Next.js 16 App Router, Jest + React Testing Library, `qs` for URL state, `geomagnetism` npm package (new dependency).
+
+**Spec:** `docs/superpowers/specs/2026-05-09-position-intelligence-design.md`
+
+---
+
+## File Structure
+
+**New files:**
+- `src/utils/positionParser.ts` — pure parser, all 8 formats, returns discriminated union
+- `src/utils/positionMath.ts` — spherical geodesic destination calculation
+- `src/utils/magvar.ts` — wrapper around `geomagnetism`
+- `src/utils/__tests__/positionParser.test.ts`
+- `src/utils/__tests__/positionMath.test.ts`
+- `src/utils/__tests__/magvar.test.ts`
+- `src/components/PositionInput.tsx`
+- `src/components/PositionInput.test.tsx`
+
+**Modified:**
+- `src/utils/types.ts` — add `position` to `WorksheetData`
+- `src/utils/aviationWeatherApi.ts` — add `getNavaidInfo` and `NavaidResponse`
+- `src/utils/__tests__/aviationWeatherApi.test.ts` — coverage for `getNavaidInfo`
+- `src/components/SortieInfo.tsx` — replace inline route input; thread `position` through state
+- `src/components/SortieInfo.test.tsx` — coverage for position wiring
+- `src/components/AppContainer.tsx` — initial state for `position`
+- `src/utils/__tests__/urlState.test.ts` — coverage for `position` field round-trip
+- `package.json` — add `geomagnetism` dependency
+
+**Implementation note on the `position` type:** the spec describes `position: [number, number] | null`. The existing URL state machinery in `urlState.ts` distinguishes value types via array hints in initialState. The simplest representation that fits is `position: [number | null, number | null]` with the convention that `[null, null]` means "not set" — analogous to how `temp`, `altimeter`, and `altitude` already use null-bearing tuples in `WorksheetData`. The user-facing semantics are unchanged. The plan uses this representation.
+
+---
+
+## Task 1: Add `position` field to `WorksheetData` type and `AppContainer` initial state
+
+**Files:**
+- Modify: `src/utils/types.ts`
+- Modify: `src/components/AppContainer.tsx`
+- Test: `src/utils/__tests__/urlState.test.ts`
+
+- [ ] **Step 1: Write failing URL-state round-trip test for `position`**
+
+Append to `src/utils/__tests__/urlState.test.ts` (inside the existing `describe("serializeState/deserializeState round trip")` block — find an analogous existing block and add this `it`):
+
+```ts
+it("should round-trip position field as length-2 number array", () => {
+  const initial = {
+    route: "",
+    position: [null, null] as [number | null, number | null],
+  };
+  const state = {
+    ...initial,
+    route: "KOGD/285/34",
+    position: [41.4321, -112.7042] as [number | null, number | null],
+  };
+  const serialized = serializeState(state);
+  const deserialized = deserializeState(serialized, initial);
+  expect(deserialized.position).toEqual([41.4321, -112.7042]);
+  expect(deserialized.route).toBe("KOGD/285/34");
+});
+
+it("should omit position field from URL when both values are null", () => {
+  const initial = {
+    route: "",
+    position: [null, null] as [number | null, number | null],
+  };
+  const state = { ...initial, position: [null, null] as [number | null, number | null] };
+  const serialized = serializeState(state);
+  expect(serialized).not.toContain("position");
+});
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `npx jest src/utils/__tests__/urlState.test.ts -t "position field"`
+Expected: FAIL — `position` not in initial state, or value not preserved.
+
+- [ ] **Step 3: Add `position` to `WorksheetData`**
+
+Edit `src/utils/types.ts`. Find the `WorksheetData` interface (lines 4-33) and add `position` after the `route` field:
+
+```ts
+  route: string; // Area of Operations/Route
+  position: [number | null, number | null]; // [lat, lon] in DD.dddd; [null, null] when unset
+```
+
+- [ ] **Step 4: Add `position` to `AppContainer` initial state**
+
+Edit `src/components/AppContainer.tsx`. Find the `useUrlState` initial-state object (line 35-76) and add a `position` field after `route`:
+
+```ts
+    route: "",
+    position: [null, null] as [number | null, number | null],
+```
+
+- [ ] **Step 5: Run test, verify it passes**
+
+Run: `npx jest src/utils/__tests__/urlState.test.ts -t "position field"`
+Expected: PASS — both tests green.
+
+- [ ] **Step 6: Run full type check + lint**
+
+Run: `npm run lint && npx tsc --noEmit`
+Expected: clean — `position` propagates through `WorksheetData`-typed code without type errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/utils/types.ts src/components/AppContainer.tsx src/utils/__tests__/urlState.test.ts
+git commit -m "Add position field to WorksheetData
+
+Adds [lat, lon] tuple alongside the free-text route field. URL state
+treats [null, null] as unset and omits the field from query strings."
+```
+
+---
+
+## Task 2: Add `geomagnetism` dependency
+
+**Files:**
+- Modify: `package.json` (via `npm install`)
+- Modify: `package-lock.json`
+
+- [ ] **Step 1: Install the package**
+
+Run: `npm install geomagnetism`
+
+- [ ] **Step 2: Verify it's in `dependencies`**
+
+Run: `grep geomagnetism package.json`
+Expected: line shows `"geomagnetism": "^...",` under dependencies.
+
+- [ ] **Step 3: Smoke-check the API surface**
+
+Run: `node -e "const g = require('geomagnetism'); console.log(g.model().point([40, -111]).decl);"`
+Expected: a number (typically positive ~10-12 for Utah). If the API differs (e.g., `model.point()` is named differently in the installed version), note the actual surface in a comment for Task 9.
+
+- [ ] **Step 4: Run existing tests to confirm no regression**
+
+Run: `npm test -- --silent`
+Expected: all existing tests pass; no missing-module errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add package.json package-lock.json
+git commit -m "Add geomagnetism dependency for WMM magnetic variation"
+```
+
+---
+
+## Task 3: Position parser — decimal formats (kinds 1, 2, plus comma separator)
+
+**Files:**
+- Create: `src/utils/positionParser.ts`
+- Test: `src/utils/__tests__/positionParser.test.ts`
+
+- [ ] **Step 1: Write failing tests for decimal parsing**
+
+Create `src/utils/__tests__/positionParser.test.ts`:
+
+```ts
+import { parsePosition } from "../positionParser";
+
+describe("parsePosition - decimal formats", () => {
+  it("parses DD.dd with N/W letters", () => {
+    const result = parsePosition("36.01N/75.50W");
+    expect(result.kind).toBe("decimal");
+    if (result.kind === "decimal") {
+      expect(result.lat).toBe(36.01);
+      expect(result.lon).toBe(-75.5);
+    }
+  });
+
+  it("parses DD.dd with S/E letters", () => {
+    const result = parsePosition("36.01S/75.50E");
+    expect(result.kind).toBe("decimal");
+    if (result.kind === "decimal") {
+      expect(result.lat).toBe(-36.01);
+      expect(result.lon).toBe(75.5);
+    }
+  });
+
+  it("parses DD.dd with minus signs", () => {
+    const result = parsePosition("36.01/-75.50");
+    expect(result.kind).toBe("decimal");
+    if (result.kind === "decimal") {
+      expect(result.lat).toBe(36.01);
+      expect(result.lon).toBe(-75.5);
+    }
+  });
+
+  it("accepts comma + space separator for decimal-with-minus", () => {
+    const result = parsePosition("41.4321, -112.7042");
+    expect(result.kind).toBe("decimal");
+    if (result.kind === "decimal") {
+      expect(result.lat).toBe(41.4321);
+      expect(result.lon).toBe(-112.7042);
+    }
+  });
+
+  it("rounds to 4 decimal places", () => {
+    const result = parsePosition("36.123456N/75.987654W");
+    expect(result.kind).toBe("decimal");
+    if (result.kind === "decimal") {
+      expect(result.lat).toBe(36.1235);
+      expect(result.lon).toBe(-75.9877);
+    }
+  });
+
+  it("rejects out-of-range latitude", () => {
+    const result = parsePosition("91.00N/75.50W");
+    expect(result.kind).toBe("unrecognized");
+  });
+
+  it("rejects out-of-range longitude", () => {
+    const result = parsePosition("36.01N/181.00W");
+    expect(result.kind).toBe("unrecognized");
+  });
+
+  it("preserves raw input on success", () => {
+    const result = parsePosition("36.01N/75.50W");
+    expect(result.raw).toBe("36.01N/75.50W");
+  });
+
+  it("preserves raw input on unrecognized", () => {
+    const result = parsePosition("Cache Valley");
+    expect(result.kind).toBe("unrecognized");
+    expect(result.raw).toBe("Cache Valley");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `npx jest src/utils/__tests__/positionParser.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement minimal parser for decimal kinds**
+
+Create `src/utils/positionParser.ts`:
+
+```ts
+export type ParsedPosition =
+  | { kind: "decimal";      raw: string; lat: number; lon: number }
+  | { kind: "dms";          raw: string; lat: number; lon: number }
+  | { kind: "ddm";          raw: string; lat: number; lon: number }
+  | { kind: "airport-rd";   raw: string; stationId: string; radial: number; distanceNm: number }
+  | { kind: "vor-rd";       raw: string; stationId: string; radial: number; distanceNm: number }
+  | { kind: "unrecognized"; raw: string };
+
+const round4 = (n: number): number => Math.round(n * 10000) / 10000;
+
+const inRange = (lat: number, lon: number): boolean =>
+  lat >= -90 && lat <= 90 && lon >= -180 && lon <= 180;
+
+const tryDecimalLetters = (s: string): { lat: number; lon: number } | null => {
+  const m = s.match(/^([\d.]+)([NS])\/([\d.]+)([EW])$/);
+  if (!m) return null;
+  const lat = Number(m[1]) * (m[2] === "S" ? -1 : 1);
+  const lon = Number(m[3]) * (m[4] === "W" ? -1 : 1);
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null;
+  if (!inRange(lat, lon)) return null;
+  return { lat: round4(lat), lon: round4(lon) };
+};
+
+const tryDecimalMinus = (s: string): { lat: number; lon: number } | null => {
+  // Accept either `/` or `,` (with optional whitespace) as separator
+  const m = s.match(/^(-?[\d.]+)\s*[/,]\s*(-?[\d.]+)$/);
+  if (!m) return null;
+  const lat = Number(m[1]);
+  const lon = Number(m[2]);
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null;
+  if (!inRange(lat, lon)) return null;
+  return { lat: round4(lat), lon: round4(lon) };
+};
+
+export function parsePosition(input: string): ParsedPosition {
+  const raw = input;
+  const s = input.trim().toUpperCase();
+  if (s === "") return { kind: "unrecognized", raw };
+
+  const letters = tryDecimalLetters(s);
+  if (letters) return { kind: "decimal", raw, ...letters };
+
+  const minus = tryDecimalMinus(s);
+  if (minus) return { kind: "decimal", raw, ...minus };
+
+  return { kind: "unrecognized", raw };
+}
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+Run: `npx jest src/utils/__tests__/positionParser.test.ts`
+Expected: PASS — all decimal-format tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/positionParser.ts src/utils/__tests__/positionParser.test.ts
+git commit -m "Add position parser for decimal-degree formats
+
+Supports DD.dd with N/S/E/W letters, DD.dd with minus signs, and
+comma-separated decimal pairs. Out-of-range values fall through
+to unrecognized."
+```
+
+---
+
+## Task 4: Position parser — DDM (degree-decimal-minutes) formats (kinds 5, 6)
+
+**Files:**
+- Modify: `src/utils/positionParser.ts`
+- Modify: `src/utils/__tests__/positionParser.test.ts`
+
+- [ ] **Step 1: Write failing tests for DDM**
+
+Append to `src/utils/__tests__/positionParser.test.ts`:
+
+```ts
+describe("parsePosition - DDM (degree-decimal-minutes)", () => {
+  it("parses DDM with letters", () => {
+    const result = parsePosition("3600.86N/07530.07W");
+    expect(result.kind).toBe("ddm");
+    if (result.kind === "ddm") {
+      // 36 + 0.86/60 = 36.0143...
+      expect(result.lat).toBe(36.0143);
+      // 75 + 30.07/60 = 75.5012... (negated)
+      expect(result.lon).toBe(-75.5012);
+    }
+  });
+
+  it("parses DDM with minus", () => {
+    const result = parsePosition("3600.86/-07530.07");
+    expect(result.kind).toBe("ddm");
+    if (result.kind === "ddm") {
+      expect(result.lat).toBe(36.0143);
+      expect(result.lon).toBe(-75.5012);
+    }
+  });
+
+  it("rejects DDM with minutes >= 60", () => {
+    const result = parsePosition("3660.00N/07530.07W");
+    expect(result.kind).toBe("unrecognized");
+  });
+
+  it("rejects DDM with degrees out of range", () => {
+    const result = parsePosition("9100.00N/07530.07W");
+    expect(result.kind).toBe("unrecognized");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `npx jest src/utils/__tests__/positionParser.test.ts -t "DDM"`
+Expected: FAIL — DDM format falls through to `unrecognized`.
+
+- [ ] **Step 3: Add DDM parser helpers and wire into `parsePosition`**
+
+Edit `src/utils/positionParser.ts`. Add helpers above `parsePosition`:
+
+```ts
+const ddmFromParts = (degStr: string, minStr: string): number | null => {
+  const deg = Number(degStr);
+  const min = Number(minStr);
+  if (!Number.isFinite(deg) || !Number.isFinite(min)) return null;
+  if (min < 0 || min >= 60) return null;
+  return deg + min / 60;
+};
+
+const tryDdmLetters = (s: string): { lat: number; lon: number } | null => {
+  // \d{2}\d{2}\.\d+ for lat (DDMM.mm), \d{3}\d{2}\.\d+ for lon (DDDMM.mm)
+  const m = s.match(/^(\d{2})(\d{2}\.\d+)([NS])\/(\d{3})(\d{2}\.\d+)([EW])$/);
+  if (!m) return null;
+  const latVal = ddmFromParts(m[1], m[2]);
+  const lonVal = ddmFromParts(m[4], m[5]);
+  if (latVal === null || lonVal === null) return null;
+  const lat = latVal * (m[3] === "S" ? -1 : 1);
+  const lon = lonVal * (m[6] === "W" ? -1 : 1);
+  if (!inRange(lat, lon)) return null;
+  return { lat: round4(lat), lon: round4(lon) };
+};
+
+const tryDdmMinus = (s: string): { lat: number; lon: number } | null => {
+  const m = s.match(/^(\d{2})(\d{2}\.\d+)\/(-?)(\d{3})(\d{2}\.\d+)$/);
+  if (!m) return null;
+  const latVal = ddmFromParts(m[1], m[2]);
+  const lonVal = ddmFromParts(m[4], m[5]);
+  if (latVal === null || lonVal === null) return null;
+  const lat = latVal;
+  const lon = lonVal * (m[3] === "-" ? -1 : 1);
+  if (!inRange(lat, lon)) return null;
+  return { lat: round4(lat), lon: round4(lon) };
+};
+```
+
+Update `parsePosition` to try DDM before decimal (since DDM with letters has its own shape, but decimal-with-letters could match parts of it; ordering ensures specificity):
+
+```ts
+export function parsePosition(input: string): ParsedPosition {
+  const raw = input;
+  const s = input.trim().toUpperCase();
+  if (s === "") return { kind: "unrecognized", raw };
+
+  const ddmL = tryDdmLetters(s);
+  if (ddmL) return { kind: "ddm", raw, ...ddmL };
+
+  const ddmM = tryDdmMinus(s);
+  if (ddmM) return { kind: "ddm", raw, ...ddmM };
+
+  const decL = tryDecimalLetters(s);
+  if (decL) return { kind: "decimal", raw, ...decL };
+
+  const decM = tryDecimalMinus(s);
+  if (decM) return { kind: "decimal", raw, ...decM };
+
+  return { kind: "unrecognized", raw };
+}
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+Run: `npx jest src/utils/__tests__/positionParser.test.ts`
+Expected: PASS — all decimal AND DDM tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/positionParser.ts src/utils/__tests__/positionParser.test.ts
+git commit -m "Position parser: add DDM (deg-decimal-min) formats"
+```
+
+---
+
+## Task 5: Position parser — DMS (degree-minute-second) formats (kinds 3, 4)
+
+**Files:**
+- Modify: `src/utils/positionParser.ts`
+- Modify: `src/utils/__tests__/positionParser.test.ts`
+
+- [ ] **Step 1: Write failing tests for DMS**
+
+Append to `src/utils/__tests__/positionParser.test.ts`:
+
+```ts
+describe("parsePosition - DMS (degree-minute-second)", () => {
+  it("parses DMS with letters", () => {
+    const result = parsePosition("360051N/0753004W");
+    expect(result.kind).toBe("dms");
+    if (result.kind === "dms") {
+      // 36 + 0/60 + 51/3600 = 36.01416...  → 36.0142
+      expect(result.lat).toBe(36.0142);
+      // -(75 + 30/60 + 4/3600) = -75.50111... → -75.5011
+      expect(result.lon).toBe(-75.5011);
+    }
+  });
+
+  it("parses DMS with minus", () => {
+    const result = parsePosition("360051/-0753004");
+    expect(result.kind).toBe("dms");
+    if (result.kind === "dms") {
+      expect(result.lat).toBe(36.0142);
+      expect(result.lon).toBe(-75.5011);
+    }
+  });
+
+  it("rejects DMS with seconds >= 60", () => {
+    const result = parsePosition("360060N/0753004W");
+    expect(result.kind).toBe("unrecognized");
+  });
+
+  it("rejects DMS with minutes >= 60", () => {
+    const result = parsePosition("366000N/0753004W");
+    expect(result.kind).toBe("unrecognized");
+  });
+
+  it("rejects DMS with latitude > 90", () => {
+    const result = parsePosition("910000N/0753004W");
+    expect(result.kind).toBe("unrecognized");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `npx jest src/utils/__tests__/positionParser.test.ts -t "DMS"`
+Expected: FAIL.
+
+- [ ] **Step 3: Add DMS parser helpers and wire into `parsePosition` ordering**
+
+Edit `src/utils/positionParser.ts`. Add helpers above `parsePosition`:
+
+```ts
+const dmsFromParts = (degStr: string, minStr: string, secStr: string): number | null => {
+  const deg = Number(degStr);
+  const min = Number(minStr);
+  const sec = Number(secStr);
+  if (!Number.isFinite(deg) || !Number.isFinite(min) || !Number.isFinite(sec)) return null;
+  if (min < 0 || min >= 60) return null;
+  if (sec < 0 || sec >= 60) return null;
+  return deg + min / 60 + sec / 3600;
+};
+
+const tryDmsLetters = (s: string): { lat: number; lon: number } | null => {
+  // DDMMSS for lat (6 digits), DDDMMSS for lon (7 digits)
+  const m = s.match(/^(\d{2})(\d{2})(\d{2})([NS])\/(\d{3})(\d{2})(\d{2})([EW])$/);
+  if (!m) return null;
+  const latVal = dmsFromParts(m[1], m[2], m[3]);
+  const lonVal = dmsFromParts(m[5], m[6], m[7]);
+  if (latVal === null || lonVal === null) return null;
+  const lat = latVal * (m[4] === "S" ? -1 : 1);
+  const lon = lonVal * (m[8] === "W" ? -1 : 1);
+  if (!inRange(lat, lon)) return null;
+  return { lat: round4(lat), lon: round4(lon) };
+};
+
+const tryDmsMinus = (s: string): { lat: number; lon: number } | null => {
+  const m = s.match(/^(\d{2})(\d{2})(\d{2})\/(-?)(\d{3})(\d{2})(\d{2})$/);
+  if (!m) return null;
+  const latVal = dmsFromParts(m[1], m[2], m[3]);
+  const lonVal = dmsFromParts(m[5], m[6], m[7]);
+  if (latVal === null || lonVal === null) return null;
+  const lat = latVal;
+  const lon = lonVal * (m[4] === "-" ? -1 : 1);
+  if (!inRange(lat, lon)) return null;
+  return { lat: round4(lat), lon: round4(lon) };
+};
+```
+
+Update `parsePosition` ordering — DMS before DDM (DMS is more specific because it has no `.` in the lat/lon body). Order from most specific to least:
+
+```ts
+export function parsePosition(input: string): ParsedPosition {
+  const raw = input;
+  const s = input.trim().toUpperCase();
+  if (s === "") return { kind: "unrecognized", raw };
+
+  const dmsL = tryDmsLetters(s);
+  if (dmsL) return { kind: "dms", raw, ...dmsL };
+
+  const dmsM = tryDmsMinus(s);
+  if (dmsM) return { kind: "dms", raw, ...dmsM };
+
+  const ddmL = tryDdmLetters(s);
+  if (ddmL) return { kind: "ddm", raw, ...ddmL };
+
+  const ddmM = tryDdmMinus(s);
+  if (ddmM) return { kind: "ddm", raw, ...ddmM };
+
+  const decL = tryDecimalLetters(s);
+  if (decL) return { kind: "decimal", raw, ...decL };
+
+  const decM = tryDecimalMinus(s);
+  if (decM) return { kind: "decimal", raw, ...decM };
+
+  return { kind: "unrecognized", raw };
+}
+```
+
+- [ ] **Step 4: Run all parser tests**
+
+Run: `npx jest src/utils/__tests__/positionParser.test.ts`
+Expected: PASS — decimal, DDM, DMS all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/positionParser.ts src/utils/__tests__/positionParser.test.ts
+git commit -m "Position parser: add DMS (deg-min-sec) formats"
+```
+
+---
+
+## Task 6: Position parser — radial-distance kinds (Airport, VOR)
+
+**Files:**
+- Modify: `src/utils/positionParser.ts`
+- Modify: `src/utils/__tests__/positionParser.test.ts`
+
+- [ ] **Step 1: Write failing tests for radial-distance**
+
+Append to `src/utils/__tests__/positionParser.test.ts`:
+
+```ts
+describe("parsePosition - radial-distance", () => {
+  it("parses 4-letter ID as airport-rd", () => {
+    const result = parsePosition("KOGD/285/34");
+    expect(result.kind).toBe("airport-rd");
+    if (result.kind === "airport-rd") {
+      expect(result.stationId).toBe("KOGD");
+      expect(result.radial).toBe(285);
+      expect(result.distanceNm).toBe(34);
+    }
+  });
+
+  it("parses 3-letter ID as vor-rd", () => {
+    const result = parsePosition("OGD/285/34");
+    expect(result.kind).toBe("vor-rd");
+    if (result.kind === "vor-rd") {
+      expect(result.stationId).toBe("OGD");
+      expect(result.radial).toBe(285);
+      expect(result.distanceNm).toBe(34);
+    }
+  });
+
+  it("uppercases lowercase station id", () => {
+    const result = parsePosition("kogd/285/34");
+    expect(result.kind).toBe("airport-rd");
+    if (result.kind === "airport-rd") {
+      expect(result.stationId).toBe("KOGD");
+    }
+  });
+
+  it("accepts decimal distance", () => {
+    const result = parsePosition("KOGD/285/34.5");
+    expect(result.kind).toBe("airport-rd");
+    if (result.kind === "airport-rd") {
+      expect(result.distanceNm).toBe(34.5);
+    }
+  });
+
+  it("rejects radial of fewer than 3 digits", () => {
+    const result = parsePosition("KOGD/85/34");
+    expect(result.kind).toBe("unrecognized");
+  });
+
+  it("rejects radial > 360", () => {
+    const result = parsePosition("KOGD/400/34");
+    expect(result.kind).toBe("unrecognized");
+  });
+
+  it("rejects distance > 500 nm", () => {
+    const result = parsePosition("KOGD/285/600");
+    expect(result.kind).toBe("unrecognized");
+  });
+
+  it("rejects negative distance", () => {
+    const result = parsePosition("KOGD/285/-5");
+    expect(result.kind).toBe("unrecognized");
+  });
+
+  it("accepts zero distance", () => {
+    const result = parsePosition("KOGD/285/0");
+    expect(result.kind).toBe("airport-rd");
+    if (result.kind === "airport-rd") {
+      expect(result.distanceNm).toBe(0);
+    }
+  });
+
+  it("ignores 5-letter station id", () => {
+    const result = parsePosition("ABCDE/285/34");
+    expect(result.kind).toBe("unrecognized");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `npx jest src/utils/__tests__/positionParser.test.ts -t "radial-distance"`
+Expected: FAIL — falls through to unrecognized.
+
+- [ ] **Step 3: Add radial-distance parser**
+
+Edit `src/utils/positionParser.ts`. Add helper above `parsePosition`:
+
+```ts
+const tryRadialDistance = (
+  s: string
+): { kind: "airport-rd" | "vor-rd"; stationId: string; radial: number; distanceNm: number } | null => {
+  // Letters 3 or 4, slash, exactly 3-digit radial, slash, distance (int or decimal)
+  const m = s.match(/^([A-Z]{3,4})\/(\d{3})\/(\d+(?:\.\d+)?)$/);
+  if (!m) return null;
+  const stationId = m[1];
+  const radial = Number(m[2]);
+  const distanceNm = Number(m[3]);
+  if (radial < 0 || radial > 360) return null;
+  if (distanceNm < 0 || distanceNm > 500) return null;
+  const kind = stationId.length === 4 ? "airport-rd" : "vor-rd";
+  return { kind, stationId, radial, distanceNm };
+};
+```
+
+Update `parsePosition` to try radial-distance first (most specific shape — three slash-delimited tokens with letters first):
+
+```ts
+export function parsePosition(input: string): ParsedPosition {
+  const raw = input;
+  const s = input.trim().toUpperCase();
+  if (s === "") return { kind: "unrecognized", raw };
+
+  const rd = tryRadialDistance(s);
+  if (rd) return { ...rd, raw };
+
+  const dmsL = tryDmsLetters(s);
+  if (dmsL) return { kind: "dms", raw, ...dmsL };
+
+  const dmsM = tryDmsMinus(s);
+  if (dmsM) return { kind: "dms", raw, ...dmsM };
+
+  const ddmL = tryDdmLetters(s);
+  if (ddmL) return { kind: "ddm", raw, ...ddmL };
+
+  const ddmM = tryDdmMinus(s);
+  if (ddmM) return { kind: "ddm", raw, ...ddmM };
+
+  const decL = tryDecimalLetters(s);
+  if (decL) return { kind: "decimal", raw, ...decL };
+
+  const decM = tryDecimalMinus(s);
+  if (decM) return { kind: "decimal", raw, ...decM };
+
+  return { kind: "unrecognized", raw };
+}
+```
+
+- [ ] **Step 4: Run all parser tests**
+
+Run: `npx jest src/utils/__tests__/positionParser.test.ts`
+Expected: PASS — every parser test green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/positionParser.ts src/utils/__tests__/positionParser.test.ts
+git commit -m "Position parser: add airport/VOR radial-distance kinds
+
+Discriminates by station ID length: 4 chars -> airport-rd, 3 chars -> vor-rd."
+```
+
+---
+
+## Task 7: Geodesic destination math
+
+**Files:**
+- Create: `src/utils/positionMath.ts`
+- Test: `src/utils/__tests__/positionMath.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `src/utils/__tests__/positionMath.test.ts`:
+
+```ts
+import { geodesicDestination } from "../positionMath";
+
+describe("geodesicDestination", () => {
+  it("travels east 60nm from (0, 0) ≈ (0, 1°)", () => {
+    const { lat, lon } = geodesicDestination(0, 0, 90, 60);
+    expect(lat).toBeCloseTo(0, 4);
+    expect(lon).toBeCloseTo(1.0, 2);
+  });
+
+  it("travels north 60nm from (0, 0) ≈ (1°, 0)", () => {
+    const { lat, lon } = geodesicDestination(0, 0, 0, 60);
+    expect(lat).toBeCloseTo(1.0, 2);
+    expect(lon).toBeCloseTo(0, 4);
+  });
+
+  it("zero distance returns starting point", () => {
+    const { lat, lon } = geodesicDestination(41.5, -112.5, 285, 0);
+    expect(lat).toBeCloseTo(41.5, 6);
+    expect(lon).toBeCloseTo(-112.5, 6);
+  });
+
+  it("normalizes longitude across antimeridian", () => {
+    // From near +180, traveling east, lon should wrap to negative.
+    const { lon } = geodesicDestination(0, 179, 90, 120);
+    expect(lon).toBeLessThan(0);
+    expect(lon).toBeGreaterThan(-180);
+  });
+
+  it("KOGD-like reference: (41.20, -112.01) + true bearing 297° + 34nm", () => {
+    // Hand-computed reference point — within 0.05° tolerance.
+    const { lat, lon } = geodesicDestination(41.2, -112.01, 297, 34);
+    expect(lat).toBeCloseTo(41.46, 1);
+    expect(lon).toBeCloseTo(-112.69, 1);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `npx jest src/utils/__tests__/positionMath.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement geodesic destination**
+
+Create `src/utils/positionMath.ts`:
+
+```ts
+const EARTH_RADIUS_NM = 3440.065;
+const toRad = (d: number): number => (d * Math.PI) / 180;
+const toDeg = (r: number): number => (r * 180) / Math.PI;
+
+/**
+ * Spherical-earth direct geodesic.
+ * Given a start lat/lon, a TRUE bearing (degrees, clockwise from north),
+ * and a distance in nautical miles, returns the destination lat/lon.
+ */
+export function geodesicDestination(
+  startLat: number,
+  startLon: number,
+  trueBearingDeg: number,
+  distanceNm: number
+): { lat: number; lon: number } {
+  const angularDistance = distanceNm / EARTH_RADIUS_NM;
+  const lat1 = toRad(startLat);
+  const lon1 = toRad(startLon);
+  const brng = toRad(trueBearingDeg);
+
+  const sinLat2 =
+    Math.sin(lat1) * Math.cos(angularDistance) +
+    Math.cos(lat1) * Math.sin(angularDistance) * Math.cos(brng);
+  const lat2 = Math.asin(sinLat2);
+
+  const y = Math.sin(brng) * Math.sin(angularDistance) * Math.cos(lat1);
+  const x = Math.cos(angularDistance) - Math.sin(lat1) * sinLat2;
+  const lon2 = lon1 + Math.atan2(y, x);
+
+  // Normalize longitude to [-180, 180]
+  const lon2Norm = ((toDeg(lon2) + 540) % 360) - 180;
+
+  return { lat: toDeg(lat2), lon: lon2Norm };
+}
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+Run: `npx jest src/utils/__tests__/positionMath.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/positionMath.ts src/utils/__tests__/positionMath.test.ts
+git commit -m "Add spherical geodesic destination math
+
+Pure function: start lat/lon + true bearing + distance (nm) -> destination.
+Earth radius 3440.065 nm. Longitude normalized to [-180, 180]."
+```
+
+---
+
+## Task 8: Magnetic variation wrapper (`magvar.ts`)
+
+**Files:**
+- Create: `src/utils/magvar.ts`
+- Test: `src/utils/__tests__/magvar.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `src/utils/__tests__/magvar.test.ts`:
+
+```ts
+import { magneticVariation } from "../magvar";
+
+describe("magneticVariation", () => {
+  it("returns positive (east) declination in northern Utah", () => {
+    // Northern Utah magvar is positive ~10-11° east in current epoch.
+    const decl = magneticVariation(41.2, -112.0);
+    expect(decl).toBeGreaterThan(5);
+    expect(decl).toBeLessThan(15);
+  });
+
+  it("returns near-zero declination near agonic line (eastern US)", () => {
+    // Agonic line passes near 0°W on the eastern seaboard in current epoch.
+    const decl = magneticVariation(35, -83);
+    expect(Math.abs(decl)).toBeLessThan(8);
+  });
+
+  it("accepts an optional date parameter", () => {
+    const declNow = magneticVariation(40, -111, new Date());
+    expect(typeof declNow).toBe("number");
+    expect(Number.isFinite(declNow)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `npx jest src/utils/__tests__/magvar.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement wrapper**
+
+Create `src/utils/magvar.ts`:
+
+```ts
+import geomagnetism from "geomagnetism";
+
+/**
+ * Magnetic variation (declination) at a point.
+ * Returns east-positive degrees: trueBearing = magneticBearing + variation.
+ *
+ * Uses the World Magnetic Model via the `geomagnetism` package.
+ */
+export function magneticVariation(
+  lat: number,
+  lon: number,
+  date: Date = new Date()
+): number {
+  const model = geomagnetism.model(date);
+  const point = model.point([lat, lon]);
+  return point.decl;
+}
+```
+
+If the smoke check in Task 2 Step 3 revealed a different API surface (e.g., `geomagnetism.model().point({lat, lon})` rather than an array), adapt this call to match.
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+Run: `npx jest src/utils/__tests__/magvar.test.ts`
+Expected: PASS — northern Utah declination in 5-15° range.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/magvar.ts src/utils/__tests__/magvar.test.ts
+git commit -m "Add magnetic variation wrapper around WMM
+
+Uses geomagnetism package; returns east-positive declination."
+```
+
+---
+
+## Task 9: Add `getNavaidInfo` to aviation weather API
+
+**Files:**
+- Modify: `src/utils/aviationWeatherApi.ts`
+- Modify: `src/utils/__tests__/aviationWeatherApi.test.ts`
+
+- [ ] **Step 1: Inspect existing test patterns**
+
+Run: `head -80 src/utils/__tests__/aviationWeatherApi.test.ts`
+Expected: see how `fetch` is mocked and how `getAirportInfo` is tested. Mirror that pattern.
+
+- [ ] **Step 2: Write failing test for `getNavaidInfo`**
+
+Append to `src/utils/__tests__/aviationWeatherApi.test.ts` (inside the top-level `describe`, mirroring the `getAirportInfo` block):
+
+```ts
+describe("getNavaidInfo", () => {
+  beforeEach(() => {
+    (global.fetch as jest.Mock).mockClear();
+  });
+
+  it("calls the navaid endpoint with comma-joined ids", async () => {
+    const mockData = [{ id: "OGD", lat: 41.5, lon: -112.76, type: "VOR-DME" }];
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockData,
+    });
+
+    const { getNavaidInfo } = await import("../aviationWeatherApi");
+    const result = await getNavaidInfo(["OGD", "DTA"]);
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+    expect(calledUrl).toContain("endpoint=navaid");
+    expect(calledUrl).toContain("ids=OGD%2CDTA");
+    expect(result).toEqual(mockData);
+  });
+
+  it("propagates 404 as APIError", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      text: async () => "Not Found",
+    });
+
+    const { getNavaidInfo, APIError } = await import("../aviationWeatherApi");
+    await expect(getNavaidInfo(["XXX"])).rejects.toBeInstanceOf(APIError);
+  });
+});
+```
+
+- [ ] **Step 3: Run test, verify it fails**
+
+Run: `npx jest src/utils/__tests__/aviationWeatherApi.test.ts -t "getNavaidInfo"`
+Expected: FAIL — `getNavaidInfo` undefined.
+
+- [ ] **Step 4: Implement `getNavaidInfo` and `NavaidResponse`**
+
+Edit `src/utils/aviationWeatherApi.ts`. After the `RunwayInfo` interface (around line 99-100), add:
+
+```ts
+export interface NavaidResponse {
+  id: string;
+  name?: string;
+  lat: number;
+  lon: number;
+  type?: string; // e.g., "VOR", "VOR-DME", "VORTAC", "NDB"
+  magvar?: number; // station declination, if exposed
+}
+```
+
+After the `getAirportInfo` function (around line 299), add:
+
+```ts
+/**
+ * Get navaid (VOR/NDB/etc.) information by ID.
+ */
+export async function getNavaidInfo(
+  ids: string[]
+): Promise<NavaidResponse[]> {
+  const params = {
+    ids: ids.join(","),
+    format: "json",
+  };
+
+  return makeApiRequest<NavaidResponse[]>("navaid", params);
+}
+```
+
+- [ ] **Step 5: Run tests, verify they pass**
+
+Run: `npx jest src/utils/__tests__/aviationWeatherApi.test.ts`
+Expected: PASS — all existing tests still green, new tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/utils/aviationWeatherApi.ts src/utils/__tests__/aviationWeatherApi.test.ts
+git commit -m "Add getNavaidInfo for VOR/NDB lookup via aviationweather.gov"
+```
+
+---
+
+## Task 10: `PositionInput` component — synchronous paths (empty, sync parse, unrecognized)
+
+**Files:**
+- Create: `src/components/PositionInput.tsx`
+- Test: `src/components/PositionInput.test.tsx`
+
+- [ ] **Step 1: Write failing tests for synchronous behavior**
+
+Create `src/components/PositionInput.test.tsx`:
+
+```tsx
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import PositionInput from "./PositionInput";
+
+describe("PositionInput - synchronous paths", () => {
+  it("renders empty input with no hint when value is empty", () => {
+    render(
+      <PositionInput rawValue="" cachedPosition={[null, null]} onChange={() => {}} />
+    );
+    expect(screen.getByRole("textbox")).toHaveValue("");
+    expect(screen.queryByText(/→/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/⚠/)).not.toBeInTheDocument();
+  });
+
+  it("shows parsed coords beneath input on decimal input", async () => {
+    jest.useFakeTimers();
+    const onChange = jest.fn();
+    render(
+      <PositionInput rawValue="" cachedPosition={[null, null]} onChange={onChange} />
+    );
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "36.01N/75.50W" },
+    });
+    act(() => {
+      jest.advanceTimersByTime(350);
+    });
+    expect(onChange).toHaveBeenCalledWith("36.01N/75.50W", [36.01, -75.5]);
+    expect(screen.getByText(/36\.0100, -75\.5000/)).toBeInTheDocument();
+    jest.useRealTimers();
+  });
+
+  it("shows warning for unrecognized input and calls onChange with null position", async () => {
+    jest.useFakeTimers();
+    const onChange = jest.fn();
+    render(
+      <PositionInput rawValue="" cachedPosition={[null, null]} onChange={onChange} />
+    );
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "Cache Valley" },
+    });
+    act(() => {
+      jest.advanceTimersByTime(350);
+    });
+    expect(onChange).toHaveBeenCalledWith("Cache Valley", [null, null]);
+    expect(screen.getByText(/Unrecognized format/)).toBeInTheDocument();
+    jest.useRealTimers();
+  });
+
+  it("renders cached position immediately without re-parsing", () => {
+    render(
+      <PositionInput
+        rawValue="KOGD/285/34"
+        cachedPosition={[41.4321, -112.7042]}
+        onChange={() => {}}
+      />
+    );
+    expect(screen.getByRole("textbox")).toHaveValue("KOGD/285/34");
+    expect(screen.getByText(/41\.4321, -112\.7042/)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `npx jest src/components/PositionInput.test.tsx`
+Expected: FAIL — component does not exist.
+
+- [ ] **Step 3: Implement minimal `PositionInput` (sync paths only)**
+
+Create `src/components/PositionInput.tsx`:
+
+```tsx
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { parsePosition } from "@/utils/positionParser";
+
+interface PositionInputProps {
+  rawValue: string;
+  cachedPosition: [number | null, number | null];
+  onChange: (route: string, position: [number | null, number | null]) => void;
+}
+
+const formatLatLon = (lat: number, lon: number): string =>
+  `${lat.toFixed(4)}, ${lon.toFixed(4)}`;
+
+export default function PositionInput({
+  rawValue,
+  cachedPosition,
+  onChange,
+}: PositionInputProps) {
+  const [localRaw, setLocalRaw] = useState(rawValue);
+  const lastPushed = useRef(rawValue);
+  const [hint, setHint] = useState<{ type: "ok" | "warn"; text: string } | null>(
+    cachedPosition[0] !== null && cachedPosition[1] !== null
+      ? { type: "ok", text: `→ ${formatLatLon(cachedPosition[0]!, cachedPosition[1]!)}` }
+      : null
+  );
+
+  // Sync incoming prop changes only when external (per AGENTS.md last-pushed pattern)
+  useEffect(() => {
+    if (rawValue !== lastPushed.current) {
+      setLocalRaw(rawValue);
+      if (cachedPosition[0] !== null && cachedPosition[1] !== null) {
+        setHint({
+          type: "ok",
+          text: `→ ${formatLatLon(cachedPosition[0]!, cachedPosition[1]!)}`,
+        });
+      } else if (rawValue === "") {
+        setHint(null);
+      }
+    }
+  }, [rawValue, cachedPosition]);
+
+  // Debounced parse on local edits
+  useEffect(() => {
+    if (localRaw === lastPushed.current) return;
+
+    const handle = setTimeout(() => {
+      const parsed = parsePosition(localRaw);
+      lastPushed.current = localRaw;
+
+      if (localRaw === "") {
+        setHint(null);
+        onChange("", [null, null]);
+        return;
+      }
+
+      if (parsed.kind === "decimal" || parsed.kind === "dms" || parsed.kind === "ddm") {
+        setHint({ type: "ok", text: `→ ${formatLatLon(parsed.lat, parsed.lon)}` });
+        onChange(localRaw, [parsed.lat, parsed.lon]);
+      } else if (parsed.kind === "unrecognized") {
+        setHint({
+          type: "warn",
+          text: "⚠ Unrecognized format — saved as free text",
+        });
+        onChange(localRaw, [null, null]);
+      } else {
+        // airport-rd / vor-rd handled in Task 11
+        onChange(localRaw, [null, null]);
+      }
+    }, 300);
+
+    return () => clearTimeout(handle);
+  }, [localRaw, onChange]);
+
+  return (
+    <div className="space-y-2">
+      <label htmlFor="route" className="block text-sm font-medium">
+        Area of Operations (position)
+      </label>
+      <input
+        type="text"
+        id="route"
+        name="route"
+        value={localRaw}
+        onChange={(e) => setLocalRaw(e.target.value.toUpperCase())}
+        className="w-full px-3 py-2 border rounded-md dark:bg-black/[.15] dark:border-white/[.145]"
+      />
+      {hint && (
+        <div
+          className={`text-xs ${
+            hint.type === "warn"
+              ? "text-amber-600 dark:text-amber-400"
+              : "text-gray-600 dark:text-gray-400"
+          }`}
+        >
+          {hint.text}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+Run: `npx jest src/components/PositionInput.test.tsx`
+Expected: PASS — sync-path tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/PositionInput.tsx src/components/PositionInput.test.tsx
+git commit -m "Add PositionInput component with synchronous parse paths
+
+Handles empty, decimal/DMS/DDM, and unrecognized states. Async
+airport/VOR lookup wired in next task."
+```
+
+---
+
+## Task 11: `PositionInput` — async lookup paths (airport/VOR + race protection)
+
+**Files:**
+- Modify: `src/components/PositionInput.tsx`
+- Modify: `src/components/PositionInput.test.tsx`
+
+- [ ] **Step 1: Write failing tests for async paths**
+
+Append to `src/components/PositionInput.test.tsx`:
+
+```tsx
+import { getAirportInfo, getNavaidInfo } from "@/utils/aviationWeatherApi";
+import { magneticVariation } from "@/utils/magvar";
+
+jest.mock("@/utils/aviationWeatherApi");
+jest.mock("@/utils/magvar");
+
+describe("PositionInput - async lookup paths", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (magneticVariation as jest.Mock).mockReturnValue(12); // east declination
+  });
+
+  it("shows loading hint then resolved coords for airport-rd", async () => {
+    (getAirportInfo as jest.Mock).mockResolvedValueOnce([
+      { icaoId: "KOGD", lat: 41.2, lon: -112.01 },
+    ]);
+    const onChange = jest.fn();
+    jest.useFakeTimers();
+    render(
+      <PositionInput rawValue="" cachedPosition={[null, null]} onChange={onChange} />
+    );
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "KOGD/285/34" },
+    });
+    act(() => {
+      jest.advanceTimersByTime(350);
+    });
+    expect(screen.getByText(/looking up KOGD/)).toBeInTheDocument();
+
+    jest.useRealTimers();
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getAirportInfo).toHaveBeenCalledWith(["KOGD"]);
+    expect(onChange).toHaveBeenLastCalledWith(
+      "KOGD/285/34",
+      expect.arrayContaining([expect.any(Number), expect.any(Number)])
+    );
+    expect(screen.getByText(/\(KOGD\/285\/34\)/)).toBeInTheDocument();
+  });
+
+  it("calls getNavaidInfo for 3-letter station ids", async () => {
+    (getNavaidInfo as jest.Mock).mockResolvedValueOnce([
+      { id: "OGD", lat: 41.5, lon: -112.76 },
+    ]);
+    const onChange = jest.fn();
+    jest.useFakeTimers();
+    render(
+      <PositionInput rawValue="" cachedPosition={[null, null]} onChange={onChange} />
+    );
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "OGD/285/34" },
+    });
+    act(() => {
+      jest.advanceTimersByTime(350);
+    });
+
+    jest.useRealTimers();
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getNavaidInfo).toHaveBeenCalledWith(["OGD"]);
+  });
+
+  it("shows error hint when lookup fails", async () => {
+    (getAirportInfo as jest.Mock).mockRejectedValueOnce(new Error("not found"));
+    const onChange = jest.fn();
+    jest.useFakeTimers();
+    render(
+      <PositionInput rawValue="" cachedPosition={[null, null]} onChange={onChange} />
+    );
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "KZZZ/285/34" },
+    });
+    act(() => {
+      jest.advanceTimersByTime(350);
+    });
+    jest.useRealTimers();
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByText(/Could not find KZZZ/)).toBeInTheDocument();
+    expect(onChange).toHaveBeenLastCalledWith("KZZZ/285/34", [null, null]);
+  });
+
+  it("ignores stale lookup results when input changes mid-flight (race protection)", async () => {
+    let resolveFirst: (v: unknown) => void = () => {};
+    (getAirportInfo as jest.Mock)
+      .mockImplementationOnce(
+        () => new Promise((resolve) => { resolveFirst = resolve; })
+      )
+      .mockResolvedValueOnce([{ icaoId: "KSLC", lat: 40.79, lon: -111.97 }]);
+
+    const onChange = jest.fn();
+    jest.useFakeTimers();
+    render(
+      <PositionInput rawValue="" cachedPosition={[null, null]} onChange={onChange} />
+    );
+
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "KOGD/285/34" },
+    });
+    act(() => {
+      jest.advanceTimersByTime(350);
+    });
+
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "KSLC/090/10" },
+    });
+    act(() => {
+      jest.advanceTimersByTime(350);
+    });
+
+    jest.useRealTimers();
+    // Resolve the stale (first) lookup AFTER the second was issued
+    resolveFirst([{ icaoId: "KOGD", lat: 41.2, lon: -112.01 }]);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Final hint should reference KSLC, not KOGD
+    expect(screen.queryByText(/KOGD/)).not.toBeInTheDocument();
+    expect(screen.getByText(/KSLC/)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `npx jest src/components/PositionInput.test.tsx -t "async lookup"`
+Expected: FAIL — async branches not implemented; assertions about `looking up`/`Could not find` fail.
+
+- [ ] **Step 3: Add async lookup, request-id race protection, and session cache to `PositionInput`**
+
+Edit `src/components/PositionInput.tsx`. Replace the entire effect block that handles `localRaw` changes, and add the imports + cache + helpers near the top:
+
+```tsx
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { parsePosition, type ParsedPosition } from "@/utils/positionParser";
+import { geodesicDestination } from "@/utils/positionMath";
+import { magneticVariation } from "@/utils/magvar";
+import { getAirportInfo, getNavaidInfo } from "@/utils/aviationWeatherApi";
+
+interface PositionInputProps {
+  rawValue: string;
+  cachedPosition: [number | null, number | null];
+  onChange: (route: string, position: [number | null, number | null]) => void;
+}
+
+const formatLatLon = (lat: number, lon: number): string =>
+  `${lat.toFixed(4)}, ${lon.toFixed(4)}`;
+const round4 = (n: number): number => Math.round(n * 10000) / 10000;
+
+// Module-scoped session cache: id -> {lat, lon}.
+const stationCache = new Map<string, { lat: number; lon: number }>();
+
+async function resolveStation(
+  parsed: Extract<ParsedPosition, { kind: "airport-rd" | "vor-rd" }>
+): Promise<{ lat: number; lon: number }> {
+  const cached = stationCache.get(parsed.stationId);
+  if (cached) return cached;
+
+  if (parsed.kind === "airport-rd") {
+    const [a] = await getAirportInfo([parsed.stationId]);
+    if (!a) throw new Error("not found");
+    const coords = { lat: a.lat, lon: a.lon };
+    stationCache.set(parsed.stationId, coords);
+    return coords;
+  } else {
+    const [n] = await getNavaidInfo([parsed.stationId]);
+    if (!n) throw new Error("not found");
+    const coords = { lat: n.lat, lon: n.lon };
+    stationCache.set(parsed.stationId, coords);
+    return coords;
+  }
+}
+
+function resolveRadialDistance(
+  parsed: Extract<ParsedPosition, { kind: "airport-rd" | "vor-rd" }>,
+  station: { lat: number; lon: number }
+): { lat: number; lon: number } {
+  const variation = magneticVariation(station.lat, station.lon);
+  const trueBearing = parsed.radial + variation;
+  const dest = geodesicDestination(
+    station.lat,
+    station.lon,
+    trueBearing,
+    parsed.distanceNm
+  );
+  return { lat: round4(dest.lat), lon: round4(dest.lon) };
+}
+
+export default function PositionInput({
+  rawValue,
+  cachedPosition,
+  onChange,
+}: PositionInputProps) {
+  const [localRaw, setLocalRaw] = useState(rawValue);
+  const lastPushed = useRef(rawValue);
+  const requestId = useRef(0);
+  const [hint, setHint] = useState<{ type: "ok" | "warn"; text: string } | null>(
+    cachedPosition[0] !== null && cachedPosition[1] !== null
+      ? { type: "ok", text: `→ ${formatLatLon(cachedPosition[0]!, cachedPosition[1]!)}` }
+      : null
+  );
+
+  useEffect(() => {
+    if (rawValue !== lastPushed.current) {
+      setLocalRaw(rawValue);
+      if (cachedPosition[0] !== null && cachedPosition[1] !== null) {
+        setHint({
+          type: "ok",
+          text: `→ ${formatLatLon(cachedPosition[0]!, cachedPosition[1]!)}`,
+        });
+      } else if (rawValue === "") {
+        setHint(null);
+      }
+    }
+  }, [rawValue, cachedPosition]);
+
+  useEffect(() => {
+    if (localRaw === lastPushed.current) return;
+
+    const handle = setTimeout(() => {
+      const myId = ++requestId.current;
+      const parsed = parsePosition(localRaw);
+      lastPushed.current = localRaw;
+
+      if (localRaw === "") {
+        setHint(null);
+        onChange("", [null, null]);
+        return;
+      }
+
+      if (parsed.kind === "decimal" || parsed.kind === "dms" || parsed.kind === "ddm") {
+        setHint({ type: "ok", text: `→ ${formatLatLon(parsed.lat, parsed.lon)}` });
+        onChange(localRaw, [parsed.lat, parsed.lon]);
+        return;
+      }
+
+      if (parsed.kind === "unrecognized") {
+        setHint({
+          type: "warn",
+          text: "⚠ Unrecognized format — saved as free text",
+        });
+        onChange(localRaw, [null, null]);
+        return;
+      }
+
+      // airport-rd or vor-rd
+      setHint({
+        type: "ok",
+        text: `→ looking up ${parsed.stationId}…`,
+      });
+
+      resolveStation(parsed)
+        .then((station) => {
+          if (myId !== requestId.current) return; // stale
+          const dest = resolveRadialDistance(parsed, station);
+          setHint({
+            type: "ok",
+            text: `→ ${formatLatLon(dest.lat, dest.lon)} (${parsed.raw})`,
+          });
+          onChange(localRaw, [dest.lat, dest.lon]);
+        })
+        .catch(() => {
+          if (myId !== requestId.current) return; // stale
+          setHint({
+            type: "warn",
+            text: `⚠ Could not find ${parsed.stationId}`,
+          });
+          onChange(localRaw, [null, null]);
+        });
+    }, 300);
+
+    return () => clearTimeout(handle);
+  }, [localRaw, onChange]);
+
+  return (
+    <div className="space-y-2">
+      <label htmlFor="route" className="block text-sm font-medium">
+        Area of Operations (position)
+      </label>
+      <input
+        type="text"
+        id="route"
+        name="route"
+        value={localRaw}
+        onChange={(e) => setLocalRaw(e.target.value.toUpperCase())}
+        className="w-full px-3 py-2 border rounded-md dark:bg-black/[.15] dark:border-white/[.145]"
+      />
+      {hint && (
+        <div
+          className={`text-xs ${
+            hint.type === "warn"
+              ? "text-amber-600 dark:text-amber-400"
+              : "text-gray-600 dark:text-gray-400"
+          }`}
+        >
+          {hint.text}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run all PositionInput tests**
+
+Run: `npx jest src/components/PositionInput.test.tsx`
+Expected: PASS — sync paths still green, async paths now green, race protection holds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/PositionInput.tsx src/components/PositionInput.test.tsx
+git commit -m "PositionInput: add async airport/VOR lookup with race protection
+
+Resolves station via getAirportInfo (4-letter) or getNavaidInfo (3-letter),
+applies WMM magnetic variation, runs spherical geodesic. Stale results
+guarded by request-id ref. Module-scoped session cache avoids re-fetch."
+```
+
+---
+
+## Task 12: Wire `PositionInput` into `SortieInfo`
+
+**Files:**
+- Modify: `src/components/SortieInfo.tsx`
+- Modify: `src/components/SortieInfo.test.tsx`
+
+- [ ] **Step 1: Inspect existing SortieInfo test patterns**
+
+Run: `head -120 src/components/SortieInfo.test.tsx`
+Expected: see how `onUpdate` is asserted and how form fields are queried. Mirror that.
+
+- [ ] **Step 2: Write a failing wiring test**
+
+Append to `src/components/SortieInfo.test.tsx`:
+
+```tsx
+describe("SortieInfo - position field wiring", () => {
+  it("calls onUpdate with both route and position when valid coords are entered", async () => {
+    jest.useFakeTimers();
+    const onUpdate = jest.fn();
+    render(<SortieInfo onUpdate={onUpdate} />);
+    const input = screen.getByLabelText(/Area of Operations/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "36.01N/75.50W" } });
+    act(() => {
+      jest.advanceTimersByTime(350);
+    });
+    const lastCall = onUpdate.mock.calls[onUpdate.mock.calls.length - 1][0];
+    expect(lastCall.route).toBe("36.01N/75.50W");
+    expect(lastCall.position).toEqual([36.01, -75.5]);
+    jest.useRealTimers();
+  });
+
+  it("hydrates initial position from initialData without re-parsing", () => {
+    const initialData = {
+      route: "KOGD/285/34",
+      position: [41.4321, -112.7042] as [number | null, number | null],
+    };
+    render(
+      <SortieInfo
+        initialData={initialData as never}
+        onUpdate={() => {}}
+      />
+    );
+    expect(screen.getByDisplayValue("KOGD/285/34")).toBeInTheDocument();
+    expect(screen.getByText(/41\.4321, -112\.7042/)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 3: Run tests, verify they fail**
+
+Run: `npx jest src/components/SortieInfo.test.tsx -t "position field wiring"`
+Expected: FAIL — `route` field is still a plain `<input>` and there's no `position` plumbing.
+
+- [ ] **Step 4: Replace the inline route input in `SortieInfo`**
+
+Edit `src/components/SortieInfo.tsx`. At the top, add the import:
+
+```ts
+import PositionInput from "@/components/PositionInput";
+```
+
+Update the `SortieInfoData` `Pick` (lines 12-24) to include `position`:
+
+```ts
+type SortieInfoData = Pick<
+  WorksheetData,
+  | "pilot"
+  | "date"
+  | "time"
+  | "duration"
+  | "acType"
+  | "tailN"
+  | "airport"
+  | "route"
+  | "position"
+  | "weight"
+  | "altitude"
+>;
+```
+
+Update the `useState` initializer (lines 27-38) to include `position`:
+
+```ts
+  const [formData, setFormData] = useState<SortieInfoData>({
+    pilot: "",
+    date: "",
+    time: "",
+    duration: null,
+    acType: "",
+    tailN: "",
+    airport: ["", ""],
+    route: "",
+    position: [null, null],
+    weight: null,
+    altitude: [null, null, null],
+  });
+```
+
+Replace the route input block (lines 320-332) with:
+
+```tsx
+        <PositionInput
+          rawValue={formData.route || ""}
+          cachedPosition={formData.position ?? [null, null]}
+          onChange={(route, position) => {
+            const updated = { ...formData, route, position };
+            setFormData(updated);
+            onUpdate({ route, position });
+          }}
+        />
+```
+
+Note: the existing `<div className="space-y-2">` wrapper that surrounded the old input is removed because `PositionInput` provides its own outer `<div className="space-y-2">`.
+
+- [ ] **Step 5: Run targeted tests, verify they pass**
+
+Run: `npx jest src/components/SortieInfo.test.tsx`
+Expected: PASS — new wiring tests green, existing SortieInfo tests still green. Inspect any failure for tests that previously asserted on the old `<input id="route">` and update them to use `screen.getByLabelText(/Area of Operations/i)` if they break.
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `npm test -- --silent`
+Expected: PASS across the board.
+
+- [ ] **Step 7: Run lint and type check**
+
+Run: `npm run lint && npx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/components/SortieInfo.tsx src/components/SortieInfo.test.tsx
+git commit -m "Wire PositionInput into SortieInfo
+
+Replaces inline route input with PositionInput; threads route and
+position through onUpdate together so URL state stays in sync."
+```
+
+---
+
+## Task 13: Manual browser smoke test
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Start the dev server**
+
+Run: `npm run dev`
+Expected: server up on `http://localhost:3000`.
+
+- [ ] **Step 2: Test each format manually in the browser**
+
+Open `http://localhost:3000`. In the "Area of Operations (position)" field, enter each of the following and confirm the hint that appears beneath it:
+
+| Input | Expected hint |
+|---|---|
+| `36.01N/75.50W` | `→ 36.0100, -75.5000` |
+| `36.01/-75.50` | `→ 36.0100, -75.5000` |
+| `41.43, -112.70` | `→ 41.4300, -112.7000` |
+| `360051N/0753004W` | `→ 36.0142, -75.5011` |
+| `360051/-0753004` | `→ 36.0142, -75.5011` |
+| `3600.86N/07530.07W` | `→ 36.0143, -75.5012` |
+| `3600.86/-07530.07` | `→ 36.0143, -75.5012` |
+| `KOGD/285/34` | `→ looking up KOGD…` then `→ <coords> (KOGD/285/34)` |
+| `OGD/285/34` | `→ looking up OGD…` then `→ <coords> (OGD/285/34)` |
+| `Cache Valley` | `⚠ Unrecognized format — saved as free text` |
+| `KZZZ/285/34` (bogus) | `⚠ Could not find KZZZ` |
+
+- [ ] **Step 3: Verify URL state round-trips a resolved airport**
+
+After typing `KOGD/285/34` and seeing the resolved coords:
+1. Copy the browser URL.
+2. Open it in a new tab.
+3. Confirm the field shows `KOGD/285/34` and the resolved coords appear immediately *without* a re-fetch (check Network tab — no aviation-weather call on load for the cached entry).
+
+- [ ] **Step 4: Verify free-text behavior round-trips**
+
+Type `Cache Valley`, confirm the warning, copy URL, open in new tab. Confirm the text is preserved and the same warning appears.
+
+- [ ] **Step 5: Stop dev server**
+
+Press Ctrl-C in the dev terminal.
+
+- [ ] **Step 6: Final lint + build**
+
+Run: `npm run lint && npm run build`
+Expected: clean build, no warnings introduced.
+
+- [ ] **Step 7: Commit any final tweaks (if needed)**
+
+If browser testing surfaced visual or behavioral issues, address them and commit. Otherwise, this task is verification only — no commit.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** all eight formats covered (Tasks 3-6, 10-11). Magvar via WMM (Task 8). Geodesic math (Task 7). Aviation weather navaid endpoint (Task 9). PositionInput sync + async (Tasks 10-11). SortieInfo wiring (Task 12). URL state for `position` (Task 1). Browser verification (Task 13).
+- **Type consistency:** `position: [number | null, number | null]` everywhere — types.ts, AppContainer initial state, SortieInfo Pick + state init, PositionInput prop. `ParsedPosition` discriminated union exported once from `positionParser.ts` and reused.
+- **Placeholders:** none found in plan.
+- **TDD discipline:** every code task starts with a failing test and runs it to verify failure before implementation.

--- a/docs/superpowers/specs/2026-05-09-position-intelligence-design.md
+++ b/docs/superpowers/specs/2026-05-09-position-intelligence-design.md
@@ -47,14 +47,16 @@ The `route` field in `SortieInfo` (labeled "Area of Operations (position)") is c
 // existing
 route: string;                       // raw input (unchanged)
 // new
-position: [number, number] | null;   // [lat, lon] in DD.dddd, or null when unparsed/unrecognized
+position: [number | null, number | null];   // [lat, lon] in DD.dddd; [null, null] means unset
 ```
 
 `route` remains the source of truth. `position` is an advisory cache — it is recomputed from `route` whenever `route` changes. It is never edited independently. A reloaded URL with both fields skips re-resolution and renders immediately.
 
+The implementation uses a fixed-length tuple with null sentinels (`[null, null]` = unset) rather than `[number, number] | null`, so the field plugs directly into the existing URL-state machinery. That machinery uses initial-state values as per-element type hints; tuple-of-nulls fits that pattern, where `null` as a primitive does not.
+
 ### URL state
 
-`position` serializes via the existing `qs`-based mechanism in `src/utils/urlState.ts` as a length-2 number array. When `null`, omitted entirely. URL grows by ~24 chars only when present.
+`position` serializes via the existing `qs`-based mechanism in `src/utils/urlState.ts` as a length-2 number array. When both elements are null, the field is omitted entirely (the `filterEmpty` filter drops arrays whose values are all empty). URL grows by ~24 chars only when present.
 
 ## Parser Pipeline
 

--- a/docs/superpowers/specs/2026-05-09-position-intelligence-design.md
+++ b/docs/superpowers/specs/2026-05-09-position-intelligence-design.md
@@ -1,0 +1,261 @@
+# Position Intelligence for Area of Operations
+
+**Issue:** [#90](https://github.com/jloosli/mountain-worksheet/issues/90)
+**Date:** 2026-05-09
+
+## Problem
+
+The `route` field in `SortieInfo` (labeled "Area of Operations (position)") is currently a free-text input. Pilots want to enter a position in any of the eight ForeFlight-supported formats and have the worksheet resolve it to canonical decimal degrees (DD.dddd / DD.dddd).
+
+## Goals
+
+1. Parse all eight ForeFlight position formats into decimal-degree coordinates.
+2. Preserve the pilot's original input alongside the resolved coordinates.
+3. Avoid breaking existing free-text usage — pilots may still type "Cache Valley" if they want to.
+4. Resolve airport and VOR identifiers via aviationweather.gov, applying current magnetic variation to convert magnetic radials to true bearings.
+5. Cache resolved coordinates in URL state so a reloaded URL does not re-fetch.
+
+## Supported Input Formats
+
+| # | Format | Example input | Resolves to |
+|---|---|---|---|
+| 1 | DD.dd with letters | `36.01N/75.50W` | `36.0100, -75.5000` |
+| 2 | DD.dd with minus | `36.01/-75.50` | `36.0100, -75.5000` |
+| 3 | DMS with letters | `360051N/0753004W` | `36.0142, -75.5011` |
+| 4 | DMS with minus | `360051/-0753004` | `36.0142, -75.5011` |
+| 5 | DDM with letters | `3600.86N/07530.07W` | `36.0143, -75.5012` |
+| 6 | DDM with minus | `3600.86/-07530.07` | `36.0143, -75.5012` |
+| 7 | Airport ID/radial/distance | `KOGD/285/34` | resolved via airport endpoint |
+| 8 | VOR ID/radial/distance | `OGD/285/34` | resolved via navaid endpoint |
+
+## Non-Goals
+
+- Map visualization of the parsed point
+- Multiple positions or polygon "area" representation
+- Persistent storage outside URL state
+- Showing magvar value to the user
+- Falling back from VOR → airport (or vice versa) on 3-letter ambiguity
+- Supporting separators other than `/` for the formats that use it (decimal-with-minus may also accept `,` for `41.43, -112.70`)
+
+## Data Model
+
+### `WorksheetData` additions
+
+`src/utils/types.ts`:
+
+```ts
+// existing
+route: string;                       // raw input (unchanged)
+// new
+position: [number, number] | null;   // [lat, lon] in DD.dddd, or null when unparsed/unrecognized
+```
+
+`route` remains the source of truth. `position` is an advisory cache — it is recomputed from `route` whenever `route` changes. It is never edited independently. A reloaded URL with both fields skips re-resolution and renders immediately.
+
+### URL state
+
+`position` serializes via the existing `qs`-based mechanism in `src/utils/urlState.ts` as a length-2 number array. When `null`, omitted entirely. URL grows by ~24 chars only when present.
+
+## Parser Pipeline
+
+`src/utils/positionParser.ts` — pure, sync, no I/O:
+
+```ts
+type ParsedPosition =
+  | { kind: "decimal";      raw: string; lat: number; lon: number }
+  | { kind: "dms";          raw: string; lat: number; lon: number }
+  | { kind: "ddm";          raw: string; lat: number; lon: number }
+  | { kind: "airport-rd";   raw: string; stationId: string; radial: number; distanceNm: number }
+  | { kind: "vor-rd";       raw: string; stationId: string; radial: number; distanceNm: number }
+  | { kind: "unrecognized"; raw: string };
+
+function parsePosition(raw: string): ParsedPosition;
+```
+
+### Detection order (first match wins)
+
+The decimal-with-minus pattern is the most permissive and would incorrectly match strings the DMS/DDM patterns accept; therefore the more-specific patterns must be tried first.
+
+1. **Radial-distance**: input matches `^[A-Z]{3,4}/\d{3}/\d+(\.\d+)?$`. Radial is exactly 3 digits per the issue's "Three Digit Radial" convention (e.g., `085`, not `85`). Discriminate airport vs VOR by station ID length: 4 chars → airport, 3 chars → VOR.
+2. **DMS with letters**: `^\d{6}[NS]/\d{7}[EW]$`
+3. **DMS with minus**: `^\d{6}/-?\d{7}$`
+4. **DDM with letters**: `^\d{4}\.\d+[NS]/\d{5}\.\d+[EW]$`
+5. **DDM with minus**: `^\d{4}\.\d+/-?\d{5}\.\d+$`
+6. **Decimal with letters**: `^[\d.]+[NS]/[\d.]+[EW]$`
+7. **Decimal with minus**: `^-?[\d.]+[/,]\s*-?[\d.]+$`
+8. Otherwise → `unrecognized`
+
+### Validation
+
+- lat ∈ [-90, 90], lon ∈ [-180, 180]
+- minutes/seconds < 60
+- radial ∈ [0, 360]
+- distance > 0 and < 500 nm
+- Out-of-range inputs → `unrecognized` (no exceptions thrown)
+
+### Normalization
+
+- `trim()` whitespace
+- Uppercase letters before matching
+- Round all returned `lat`/`lon` to 4 decimal places (~11m precision at the equator)
+
+### Display vs storage formats
+
+- **Storage** (`position` field, URL state): `[lat, lon]` number array, 4-decimal precision.
+- **Display** (hint beneath input): `→ 41.4321, -112.7042` — comma-separated, more readable than slash. The original input shown in `route` is whatever the pilot typed.
+
+## Math, Magvar, and Lookups
+
+### `src/utils/positionMath.ts`
+
+```ts
+function geodesicDestination(
+  startLat: number, startLon: number,
+  trueBearingDeg: number, distanceNm: number
+): { lat: number; lon: number };
+```
+
+Spherical-earth direct geodesic. Earth radius constant: 3440.065 nm. Error vs WGS84 ellipsoid is well below 4-decimal precision for sub-100nm legs.
+
+### `src/utils/magvar.ts`
+
+Thin wrapper over the `geomagnetism` npm package (World Magnetic Model). Bundles WMM coefficients (~tens of KB), no API call:
+
+```ts
+function magneticVariation(lat: number, lon: number, date?: Date): number;
+// East-positive declination in degrees.
+// trueBearing = magneticBearing + variation
+```
+
+### Aviation Weather API additions
+
+`src/utils/aviationWeatherApi.ts`:
+
+```ts
+async function getNavaidInfo(ids: string[]): Promise<NavaidResponse[]>;
+// GET /api/aviation-weather?endpoint=navaid&ids=OGD&format=json
+```
+
+Response shape (fields confirmed during implementation):
+```ts
+interface NavaidResponse {
+  id: string;
+  name?: string;
+  lat: number;
+  lon: number;
+  type?: string;     // e.g., "VOR", "VOR-DME", "VORTAC"
+  magvar?: number;   // station declination, if exposed
+}
+```
+
+The proxy at `src/app/api/aviation-weather/route.ts` already forwards arbitrary endpoints. No proxy changes anticipated unless the navaid response requires special parsing.
+
+### Resolution flow for radial-distance kinds
+
+1. Parser returns `{kind, stationId, radial, distanceNm}`.
+2. Component checks the in-memory station cache; on miss, calls `getAirportInfo([id])` or `getNavaidInfo([id])`.
+3. Compute `trueBearing = radial + magneticVariation(stationLat, stationLon)`.
+4. `geodesicDestination(stationLat, stationLon, trueBearing, distanceNm)` → final lat/lon.
+5. Round to 4dp and update `position`.
+
+### Magvar nuance
+
+A VOR's published station declination (the magvar baked into its calibration when last surveyed) can differ from current WMM by a few degrees in regions of rapid magnetic drift. For 4-decimal precision over short legs this rarely matters; we use WMM for both airport and VOR lookups. If the navaid endpoint exposes a `magvar` field, switching VORs to use that value is a future enhancement.
+
+## Component: `PositionInput`
+
+`src/components/PositionInput.tsx`:
+
+```ts
+interface PositionInputProps {
+  rawValue: string;
+  cachedPosition: [number, number] | null;
+  onChange: (route: string, position: [number, number] | null) => void;
+}
+```
+
+Replaces the inline `<input id="route">` block at `SortieInfo.tsx:320-332`. All other fields in `SortieInfo` are unchanged.
+
+### Internal state
+
+- `localRaw: string` — `<input>` display value, mirrored to `rawValue` via the ref-tracked last-pushed pattern documented in `AGENTS.md:30-37` (avoids feedback loops with the `initialData` prop in `SortieInfo`).
+- `lookupState: { status: "idle"|"loading"|"resolved"|"error", message?: string }`
+
+### Effect chain
+
+1. On `localRaw` change (300ms debounce): call `parsePosition(localRaw)`.
+2. Branch on `parsed.kind`:
+   - `decimal | dms | ddm` → call `onChange(localRaw, [round4(lat), round4(lon)])` immediately. `lookupState = idle`.
+   - `airport-rd | vor-rd` → check session cache. On hit, compute and `onChange` immediately. On miss, set `lookupState = loading`, fire API call. On success, compute, call `onChange(localRaw, [lat, lon])`, `lookupState = resolved`. On failure, `onChange(localRaw, null)`, `lookupState = error`.
+   - `unrecognized` → `onChange(localRaw, null)`, render warning hint.
+3. **Race protection:** each lookup tagged with a request ID; only the most-recent ID's result updates state.
+
+### Initial mount
+
+If `cachedPosition` is present, render it immediately. If `parsePosition(rawValue)` is sync and produces the same result, skip work. If `rawValue` is async-kind and `cachedPosition` is present, trust the cache — no re-fetch.
+
+### Visual layout
+
+The hint sits beneath the `<input>` in the same slot occupied by `sortieLocalTiming` for the date/time fields. Small, gray, no layout shift.
+
+| Parser state | Hint shown |
+|---|---|
+| empty | (none) |
+| sync parse success | `→ 41.4321, -112.7042` |
+| async lookup in flight | `→ looking up KOGD…` |
+| async lookup success | `→ 41.4321, -112.7042 (KOGD/285/34)` |
+| async lookup failed | `⚠ Could not find KOGD` |
+| unrecognized | `⚠ Unrecognized format — saved as free text` |
+
+## Edge Cases
+
+| Case | Behavior |
+|---|---|
+| `41.43, -112.70` (decimal with comma + space) | Accepted by decimal-with-minus pattern. |
+| `LAX/285/34` (3 chars; LAX is both airport IATA and VOR) | Treated as VOR per issue convention. If navaid lookup fails, surface error; do not fall back to airport. |
+| Lowercase input | Uppercased before parsing. |
+| Radial 360 vs 0 | Both accepted. |
+| Distance 0 | Accepted; resolves to station coordinates. |
+| Negative distance | Rejected → `unrecognized`. |
+| Empty input | `route = ""`, `position = null`, no hint. |
+| Network failure | `⚠ Lookup failed — check connection`. `position = null`. No auto-retry. |
+| Slow lookup (>5s) | `⚠ Lookup taking longer than expected`. Continues waiting. |
+| User edits while lookup in flight | Cancel via request ID; new debounced parse fires. |
+| Coordinates out of range | Treated as `unrecognized`. |
+| Eastern hemisphere coords (`36.01N/75.50E`) | Parsed correctly. |
+
+## Error Handling Philosophy
+
+Parser failures degrade silently to `unrecognized` (saved as free text with amber warning). Only API/network failures surface as amber warnings. No exceptions thrown to the user.
+
+## Testing
+
+| File | Coverage |
+|---|---|
+| `src/utils/__tests__/positionParser.test.ts` | Each of 8 formats × valid / invalid / edge inputs (~30 cases). Pure unit test, no mocks. |
+| `src/utils/__tests__/positionMath.test.ts` | Geodesic destination against known reference points (e.g., 0,0 + 90° + 60nm ≈ 0, 1°). Magvar wrapper smoke test. |
+| `src/utils/__tests__/aviationWeatherApi.test.ts` | New `getNavaidInfo` request shape and error path. Existing tests already mock `fetch`. |
+| `src/components/PositionInput.test.tsx` | Full flows: sync parse renders coords; async lookup renders loading then result; error path; unrecognized path; race protection (rapid edits cancel stale lookups). |
+| `src/components/SortieInfo.test.tsx` | Update to reflect new component slot; add regression test that route + position round-trip through URL state. |
+| `src/utils/__tests__/urlState.test.ts` | Add cases for `position` field serialization (length-2 number array; null omission). |
+
+## Files Changed
+
+**New files:**
+- `src/utils/positionParser.ts`
+- `src/utils/positionMath.ts`
+- `src/utils/magvar.ts`
+- `src/components/PositionInput.tsx`
+- `src/utils/__tests__/positionParser.test.ts`
+- `src/utils/__tests__/positionMath.test.ts`
+- `src/components/PositionInput.test.tsx`
+
+**Modified:**
+- `src/utils/types.ts` — add `position` to `WorksheetData`
+- `src/utils/aviationWeatherApi.ts` — add `getNavaidInfo`, `NavaidResponse`
+- `src/components/SortieInfo.tsx` — replace inline route input with `<PositionInput>`; thread `position` through state
+- `src/utils/urlState.ts` / `useUrlState.ts` — confirm length-2 number array round-trips correctly (likely no change)
+- `src/utils/__tests__/aviationWeatherApi.test.ts` — coverage for `getNavaidInfo`
+- `src/components/SortieInfo.test.tsx` — coverage for new wiring
+- `src/utils/__tests__/urlState.test.ts` — coverage for `position` field
+- `package.json` — add `geomagnetism` dependency

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@headlessui/react": "^2.2.9",
         "@heroicons/react": "^2.2.0",
+        "geomagnetism": "^0.2.0",
         "next": "^16.1.5",
         "qs": "^6.15.0",
         "react": "^19.2.0",
@@ -5846,6 +5847,12 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/geomagnetism": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/geomagnetism/-/geomagnetism-0.2.0.tgz",
+      "integrity": "sha512-dO8HJrXqah244nMe+pU5m52L90SMoi4lDA0AV3xunRxogloYV+s3aYWCW72VMMfiYis+YSAlhoKktw8aLMiJbw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -9150,7 +9157,6 @@
       "version": "8.5.14",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
       "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@headlessui/react": "^2.2.9",
     "@heroicons/react": "^2.2.0",
+    "geomagnetism": "^0.2.0",
     "next": "^16.1.5",
     "qs": "^6.15.0",
     "react": "^19.2.0",

--- a/src/components/AppContainer.tsx
+++ b/src/components/AppContainer.tsx
@@ -41,6 +41,7 @@ export default function AppContainer() {
     tailN: "",
     airport: ["", ""] as [string, string],
     route: "",
+    position: [null, null] as [number | null, number | null],
 
     // Weather Information
     wind: [

--- a/src/components/AppInputs.test.tsx
+++ b/src/components/AppInputs.test.tsx
@@ -102,7 +102,7 @@ jest.mock("./MountainQuals", () => {
 
 describe("AppInputs", () => {
   const mockOnStateUpdate = jest.fn();
-  const defaultState = {
+  const defaultState: WorksheetData = {
     pilot: "",
     date: "",
     time: "",

--- a/src/components/AppInputs.test.tsx
+++ b/src/components/AppInputs.test.tsx
@@ -111,6 +111,7 @@ describe("AppInputs", () => {
     tailN: "",
     airport: ["", ""],
     route: "",
+    position: [null, null],
     wind: [Array(5).fill(0), Array(5).fill(0), Array(5).fill(0)],
     turb: false,
     cielVis: false,

--- a/src/components/Calculations.test.tsx
+++ b/src/components/Calculations.test.tsx
@@ -156,6 +156,7 @@ describe("Calculations", () => {
     duration: null,
     acType: "C182T",
     route: "",
+    position: [null, null],
     tailN: "N12345",
     wind: [[0, 0, 0, 0, 0], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0]],
     turb: false,

--- a/src/components/PositionInput.test.tsx
+++ b/src/components/PositionInput.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import PositionInput from "./PositionInput";
+
+describe("PositionInput - synchronous paths", () => {
+  it("renders empty input with no hint when value is empty", () => {
+    render(
+      <PositionInput rawValue="" cachedPosition={[null, null]} onChange={() => {}} />
+    );
+    expect(screen.getByRole("textbox")).toHaveValue("");
+    expect(screen.queryByText(/→/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/⚠/)).not.toBeInTheDocument();
+  });
+
+  it("shows parsed coords beneath input on decimal input", async () => {
+    jest.useFakeTimers();
+    const onChange = jest.fn();
+    render(
+      <PositionInput rawValue="" cachedPosition={[null, null]} onChange={onChange} />
+    );
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "36.01N/75.50W" },
+    });
+    act(() => {
+      jest.advanceTimersByTime(350);
+    });
+    expect(onChange).toHaveBeenCalledWith("36.01N/75.50W", [36.01, -75.5]);
+    expect(screen.getByText(/36\.0100, -75\.5000/)).toBeInTheDocument();
+    jest.useRealTimers();
+  });
+
+  it("shows warning for unrecognized input and calls onChange with null position", async () => {
+    jest.useFakeTimers();
+    const onChange = jest.fn();
+    render(
+      <PositionInput rawValue="" cachedPosition={[null, null]} onChange={onChange} />
+    );
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "Cache Valley" },
+    });
+    act(() => {
+      jest.advanceTimersByTime(350);
+    });
+    expect(onChange).toHaveBeenCalledWith("CACHE VALLEY", [null, null]);
+    expect(screen.getByText(/Unrecognized format/)).toBeInTheDocument();
+    jest.useRealTimers();
+  });
+
+  it("renders cached position immediately without re-parsing", () => {
+    render(
+      <PositionInput
+        rawValue="KOGD/285/34"
+        cachedPosition={[41.4321, -112.7042]}
+        onChange={() => {}}
+      />
+    );
+    expect(screen.getByRole("textbox")).toHaveValue("KOGD/285/34");
+    expect(screen.getByText(/41\.4321, -112\.7042/)).toBeInTheDocument();
+  });
+});

--- a/src/components/PositionInput.test.tsx
+++ b/src/components/PositionInput.test.tsx
@@ -1,5 +1,10 @@
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import PositionInput from "./PositionInput";
+import { getAirportInfo, getNavaidInfo } from "@/utils/aviationWeatherApi";
+import { magneticVariation } from "@/utils/magvar";
+
+jest.mock("@/utils/aviationWeatherApi");
+jest.mock("@/utils/magvar");
 
 describe("PositionInput - synchronous paths", () => {
   it("renders empty input with no hint when value is empty", () => {
@@ -55,5 +60,132 @@ describe("PositionInput - synchronous paths", () => {
     );
     expect(screen.getByRole("textbox")).toHaveValue("KOGD/285/34");
     expect(screen.getByText(/41\.4321, -112\.7042/)).toBeInTheDocument();
+  });
+});
+
+describe("PositionInput - async lookup paths", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (magneticVariation as jest.Mock).mockReturnValue(12); // east declination
+  });
+
+  it("shows loading hint then resolved coords for airport-rd", async () => {
+    (getAirportInfo as jest.Mock).mockResolvedValueOnce([
+      { icaoId: "KOGD", lat: 41.2, lon: -112.01 },
+    ]);
+    const onChange = jest.fn();
+    jest.useFakeTimers();
+    render(
+      <PositionInput rawValue="" cachedPosition={[null, null]} onChange={onChange} />
+    );
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "KOGD/285/34" },
+    });
+    act(() => {
+      jest.advanceTimersByTime(350);
+    });
+    expect(screen.getByText(/looking up KOGD/)).toBeInTheDocument();
+
+    jest.useRealTimers();
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getAirportInfo).toHaveBeenCalledWith(["KOGD"]);
+    expect(onChange).toHaveBeenLastCalledWith(
+      "KOGD/285/34",
+      expect.arrayContaining([expect.any(Number), expect.any(Number)])
+    );
+    expect(screen.getByText(/\(KOGD\/285\/34\)/)).toBeInTheDocument();
+  });
+
+  it("calls getNavaidInfo for 3-letter station ids", async () => {
+    (getNavaidInfo as jest.Mock).mockResolvedValueOnce([
+      { id: "OGD", lat: 41.5, lon: -112.76 },
+    ]);
+    const onChange = jest.fn();
+    jest.useFakeTimers();
+    render(
+      <PositionInput rawValue="" cachedPosition={[null, null]} onChange={onChange} />
+    );
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "OGD/285/34" },
+    });
+    act(() => {
+      jest.advanceTimersByTime(350);
+    });
+
+    jest.useRealTimers();
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getNavaidInfo).toHaveBeenCalledWith(["OGD"]);
+  });
+
+  it("shows error hint when lookup fails", async () => {
+    (getAirportInfo as jest.Mock).mockRejectedValueOnce(new Error("not found"));
+    const onChange = jest.fn();
+    jest.useFakeTimers();
+    render(
+      <PositionInput rawValue="" cachedPosition={[null, null]} onChange={onChange} />
+    );
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "KZZZ/285/34" },
+    });
+    act(() => {
+      jest.advanceTimersByTime(350);
+    });
+    jest.useRealTimers();
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByText(/Could not find KZZZ/)).toBeInTheDocument();
+    expect(onChange).toHaveBeenLastCalledWith("KZZZ/285/34", [null, null]);
+  });
+
+  it("ignores stale lookup results when input changes mid-flight (race protection)", async () => {
+    let resolveFirst: (v: unknown) => void = () => {};
+    (getAirportInfo as jest.Mock)
+      .mockImplementationOnce(
+        () => new Promise((resolve) => { resolveFirst = resolve; })
+      )
+      .mockResolvedValueOnce([{ icaoId: "KSLC", lat: 40.79, lon: -111.97 }]);
+
+    const onChange = jest.fn();
+    jest.useFakeTimers();
+    render(
+      <PositionInput rawValue="" cachedPosition={[null, null]} onChange={onChange} />
+    );
+
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "KOGD/285/34" },
+    });
+    act(() => {
+      jest.advanceTimersByTime(350);
+    });
+
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "KSLC/090/10" },
+    });
+    act(() => {
+      jest.advanceTimersByTime(350);
+    });
+
+    jest.useRealTimers();
+    // Resolve the stale (first) lookup AFTER the second was issued
+    resolveFirst([{ icaoId: "KOGD", lat: 41.2, lon: -112.01 }]);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Final hint should reference KSLC, not KOGD
+    expect(screen.queryByText(/KOGD/)).not.toBeInTheDocument();
+    expect(screen.getByText(/KSLC/)).toBeInTheDocument();
   });
 });

--- a/src/components/PositionInput.test.tsx
+++ b/src/components/PositionInput.test.tsx
@@ -148,6 +148,9 @@ describe("PositionInput - async lookup paths", () => {
   });
 
   it("ignores stale lookup results when input changes mid-flight (race protection)", async () => {
+    // PAMC is uncached (KOGD is cached by the prior test); we need both
+    // stations to actually trigger a network fetch so the slow-promise
+    // mock is consumed and the race is real.
     let resolveFirst: (v: unknown) => void = () => {};
     (getAirportInfo as jest.Mock)
       .mockImplementationOnce(
@@ -162,7 +165,7 @@ describe("PositionInput - async lookup paths", () => {
     );
 
     fireEvent.change(screen.getByRole("textbox"), {
-      target: { value: "KOGD/285/34" },
+      target: { value: "PAMC/285/34" },
     });
     act(() => {
       jest.advanceTimersByTime(350);
@@ -177,15 +180,15 @@ describe("PositionInput - async lookup paths", () => {
 
     jest.useRealTimers();
     // Resolve the stale (first) lookup AFTER the second was issued
-    resolveFirst([{ icaoId: "KOGD", lat: 41.2, lon: -112.01 }]);
+    resolveFirst([{ icaoId: "PAMC", lat: 62.95, lon: -155.6 }]);
     await act(async () => {
       await Promise.resolve();
       await Promise.resolve();
       await Promise.resolve();
     });
 
-    // Final hint should reference KSLC, not KOGD
-    expect(screen.queryByText(/KOGD/)).not.toBeInTheDocument();
+    // Final hint should reference KSLC, not PAMC
+    expect(screen.queryByText(/PAMC/)).not.toBeInTheDocument();
     expect(screen.getByText(/KSLC/)).toBeInTheDocument();
   });
 });

--- a/src/components/PositionInput.tsx
+++ b/src/components/PositionInput.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { parsePosition } from "@/utils/positionParser";
+
+interface PositionInputProps {
+  rawValue: string;
+  cachedPosition: [number | null, number | null];
+  onChange: (route: string, position: [number | null, number | null]) => void;
+}
+
+const formatLatLon = (lat: number, lon: number): string =>
+  `${lat.toFixed(4)}, ${lon.toFixed(4)}`;
+
+export default function PositionInput({
+  rawValue,
+  cachedPosition,
+  onChange,
+}: PositionInputProps) {
+  const [localRaw, setLocalRaw] = useState(rawValue);
+  const lastPushed = useRef(rawValue);
+  const [hint, setHint] = useState<{ type: "ok" | "warn"; text: string } | null>(
+    cachedPosition[0] !== null && cachedPosition[1] !== null
+      ? { type: "ok", text: `→ ${formatLatLon(cachedPosition[0]!, cachedPosition[1]!)}` }
+      : null
+  );
+
+  // Sync incoming prop changes only when external (per AGENTS.md last-pushed pattern)
+  useEffect(() => {
+    if (rawValue !== lastPushed.current) {
+      setLocalRaw(rawValue);
+      if (cachedPosition[0] !== null && cachedPosition[1] !== null) {
+        setHint({
+          type: "ok",
+          text: `→ ${formatLatLon(cachedPosition[0]!, cachedPosition[1]!)}`,
+        });
+      } else if (rawValue === "") {
+        setHint(null);
+      }
+    }
+  }, [rawValue, cachedPosition]);
+
+  // Debounced parse on local edits
+  useEffect(() => {
+    if (localRaw === lastPushed.current) return;
+
+    const handle = setTimeout(() => {
+      const parsed = parsePosition(localRaw);
+      lastPushed.current = localRaw;
+
+      if (localRaw === "") {
+        setHint(null);
+        onChange("", [null, null]);
+        return;
+      }
+
+      if (parsed.kind === "decimal" || parsed.kind === "dms" || parsed.kind === "ddm") {
+        setHint({ type: "ok", text: `→ ${formatLatLon(parsed.lat, parsed.lon)}` });
+        onChange(localRaw, [parsed.lat, parsed.lon]);
+      } else if (parsed.kind === "unrecognized") {
+        setHint({
+          type: "warn",
+          text: "⚠ Unrecognized format — saved as free text",
+        });
+        onChange(localRaw, [null, null]);
+      } else {
+        // airport-rd / vor-rd handled in Task 11
+        onChange(localRaw, [null, null]);
+      }
+    }, 300);
+
+    return () => clearTimeout(handle);
+  }, [localRaw, onChange]);
+
+  return (
+    <div className="space-y-2">
+      <label htmlFor="route" className="block text-sm font-medium">
+        Area of Operations (position)
+      </label>
+      <input
+        type="text"
+        id="route"
+        name="route"
+        value={localRaw}
+        onChange={(e) => setLocalRaw(e.target.value.toUpperCase())}
+        className="w-full px-3 py-2 border rounded-md dark:bg-black/[.15] dark:border-white/[.145]"
+      />
+      {hint && (
+        <div
+          className={`text-xs ${
+            hint.type === "warn"
+              ? "text-amber-600 dark:text-amber-400"
+              : "text-gray-600 dark:text-gray-400"
+          }`}
+        >
+          {hint.text}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/PositionInput.tsx
+++ b/src/components/PositionInput.tsx
@@ -72,13 +72,19 @@ export default function PositionInput({
   useEffect(() => {
     if (rawValue !== lastPushed.current) {
       setLocalRaw(rawValue);
-      if (cachedPosition[0] !== null && cachedPosition[1] !== null) {
+      const hasCachedCoords =
+        cachedPosition[0] !== null && cachedPosition[1] !== null;
+      if (hasCachedCoords) {
         setHint({
           type: "ok",
           text: `→ ${formatLatLon(cachedPosition[0]!, cachedPosition[1]!)}`,
         });
+        // Trust the URL-cached coordinates; suppress the second effect's
+        // re-parse so we don't refetch airport/VOR lookups on hydration.
+        lastPushed.current = rawValue;
       } else if (rawValue === "") {
         setHint(null);
+        lastPushed.current = rawValue;
       }
     }
   }, [rawValue, cachedPosition]);

--- a/src/components/PositionInput.tsx
+++ b/src/components/PositionInput.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { parsePosition } from "@/utils/positionParser";
+import { parsePosition, type ParsedPosition } from "@/utils/positionParser";
+import { geodesicDestination } from "@/utils/positionMath";
+import { magneticVariation } from "@/utils/magvar";
+import { getAirportInfo, getNavaidInfo } from "@/utils/aviationWeatherApi";
 
 interface PositionInputProps {
   rawValue: string;
@@ -11,6 +14,46 @@ interface PositionInputProps {
 
 const formatLatLon = (lat: number, lon: number): string =>
   `${lat.toFixed(4)}, ${lon.toFixed(4)}`;
+const round4 = (n: number): number => Math.round(n * 10000) / 10000;
+
+// Module-scoped session cache: id -> {lat, lon}.
+const stationCache = new Map<string, { lat: number; lon: number }>();
+
+async function resolveStation(
+  parsed: Extract<ParsedPosition, { kind: "airport-rd" | "vor-rd" }>
+): Promise<{ lat: number; lon: number }> {
+  const cached = stationCache.get(parsed.stationId);
+  if (cached) return cached;
+
+  if (parsed.kind === "airport-rd") {
+    const [a] = await getAirportInfo([parsed.stationId]);
+    if (!a) throw new Error("not found");
+    const coords = { lat: a.lat, lon: a.lon };
+    stationCache.set(parsed.stationId, coords);
+    return coords;
+  } else {
+    const [n] = await getNavaidInfo([parsed.stationId]);
+    if (!n) throw new Error("not found");
+    const coords = { lat: n.lat, lon: n.lon };
+    stationCache.set(parsed.stationId, coords);
+    return coords;
+  }
+}
+
+function resolveRadialDistance(
+  parsed: Extract<ParsedPosition, { kind: "airport-rd" | "vor-rd" }>,
+  station: { lat: number; lon: number }
+): { lat: number; lon: number } {
+  const variation = magneticVariation(station.lat, station.lon);
+  const trueBearing = parsed.radial + variation;
+  const dest = geodesicDestination(
+    station.lat,
+    station.lon,
+    trueBearing,
+    parsed.distanceNm
+  );
+  return { lat: round4(dest.lat), lon: round4(dest.lon) };
+}
 
 export default function PositionInput({
   rawValue,
@@ -19,13 +62,13 @@ export default function PositionInput({
 }: PositionInputProps) {
   const [localRaw, setLocalRaw] = useState(rawValue);
   const lastPushed = useRef(rawValue);
+  const requestId = useRef(0);
   const [hint, setHint] = useState<{ type: "ok" | "warn"; text: string } | null>(
     cachedPosition[0] !== null && cachedPosition[1] !== null
       ? { type: "ok", text: `→ ${formatLatLon(cachedPosition[0]!, cachedPosition[1]!)}` }
       : null
   );
 
-  // Sync incoming prop changes only when external (per AGENTS.md last-pushed pattern)
   useEffect(() => {
     if (rawValue !== lastPushed.current) {
       setLocalRaw(rawValue);
@@ -40,11 +83,11 @@ export default function PositionInput({
     }
   }, [rawValue, cachedPosition]);
 
-  // Debounced parse on local edits
   useEffect(() => {
     if (localRaw === lastPushed.current) return;
 
     const handle = setTimeout(() => {
+      const myId = ++requestId.current;
       const parsed = parsePosition(localRaw);
       lastPushed.current = localRaw;
 
@@ -57,16 +100,42 @@ export default function PositionInput({
       if (parsed.kind === "decimal" || parsed.kind === "dms" || parsed.kind === "ddm") {
         setHint({ type: "ok", text: `→ ${formatLatLon(parsed.lat, parsed.lon)}` });
         onChange(localRaw, [parsed.lat, parsed.lon]);
-      } else if (parsed.kind === "unrecognized") {
+        return;
+      }
+
+      if (parsed.kind === "unrecognized") {
         setHint({
           type: "warn",
           text: "⚠ Unrecognized format — saved as free text",
         });
         onChange(localRaw, [null, null]);
-      } else {
-        // airport-rd / vor-rd handled in Task 11
-        onChange(localRaw, [null, null]);
+        return;
       }
+
+      // airport-rd or vor-rd
+      setHint({
+        type: "ok",
+        text: `→ looking up ${parsed.stationId}…`,
+      });
+
+      resolveStation(parsed)
+        .then((station) => {
+          if (myId !== requestId.current) return; // stale
+          const dest = resolveRadialDistance(parsed, station);
+          setHint({
+            type: "ok",
+            text: `→ ${formatLatLon(dest.lat, dest.lon)} (${parsed.raw})`,
+          });
+          onChange(localRaw, [dest.lat, dest.lon]);
+        })
+        .catch(() => {
+          if (myId !== requestId.current) return; // stale
+          setHint({
+            type: "warn",
+            text: `⚠ Could not find ${parsed.stationId}`,
+          });
+          onChange(localRaw, [null, null]);
+        });
     }, 300);
 
     return () => clearTimeout(handle);

--- a/src/components/SortieInfo.test.tsx
+++ b/src/components/SortieInfo.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import SortieInfo from "./SortieInfo";
 import type { WorksheetData } from "@/utils/types";
 
@@ -112,5 +112,37 @@ describe("SortieInfo", () => {
     const select = screen.getByLabelText(/Expected Duration/i);
     fireEvent.change(select, { target: { value: "" } });
     expect(mockOnUpdate).toHaveBeenCalledWith(expect.objectContaining({ duration: null }));
+  });
+});
+
+describe("SortieInfo - position field wiring", () => {
+  it("calls onUpdate with both route and position when valid coords are entered", async () => {
+    jest.useFakeTimers();
+    const onUpdate = jest.fn();
+    render(<SortieInfo onUpdate={onUpdate} />);
+    const input = screen.getByLabelText(/Area of Operations/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "36.01N/75.50W" } });
+    act(() => {
+      jest.advanceTimersByTime(350);
+    });
+    const lastCall = onUpdate.mock.calls[onUpdate.mock.calls.length - 1][0];
+    expect(lastCall.route).toBe("36.01N/75.50W");
+    expect(lastCall.position).toEqual([36.01, -75.5]);
+    jest.useRealTimers();
+  });
+
+  it("hydrates initial position from initialData without re-parsing", () => {
+    const initialData = {
+      route: "KOGD/285/34",
+      position: [41.4321, -112.7042] as [number | null, number | null],
+    };
+    render(
+      <SortieInfo
+        initialData={initialData as never}
+        onUpdate={() => {}}
+      />
+    );
+    expect(screen.getByDisplayValue("KOGD/285/34")).toBeInTheDocument();
+    expect(screen.getByText(/41\.4321, -112\.7042/)).toBeInTheDocument();
   });
 });

--- a/src/components/SortieInfo.test.tsx
+++ b/src/components/SortieInfo.test.tsx
@@ -11,6 +11,7 @@ const defaultInitialData: WorksheetData = {
   tailN: "",
   airport: ["", ""],
   route: "",
+  position: [null, null],
   weight: null,
   altitude: [null, null, null],
   wind: [Array(5).fill(null), Array(5).fill(null), Array(5).fill(null)],

--- a/src/components/SortieInfo.tsx
+++ b/src/components/SortieInfo.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChangeEvent, useEffect, useMemo, useState } from "react";
+import { ChangeEvent, useCallback, useEffect, useMemo, useState } from "react";
 import aircraftData from "@/data/aircraft.json";
 import type { WorksheetData } from "@/utils/types";
 import PositionInput from "@/components/PositionInput";
@@ -130,6 +130,16 @@ export default function SortieInfo({ initialData, onUpdate }: SortieInfoProps) {
     setFormData(updatedData);
     onUpdate({ duration: value });
   };
+
+  // Stable identity prevents the 60s currentTime ticker from cancelling
+  // PositionInput's pending debounce on every re-render.
+  const handlePositionChange = useCallback(
+    (route: string, position: [number | null, number | null]) => {
+      setFormData((prev) => ({ ...prev, route, position }));
+      onUpdate({ route, position });
+    },
+    [onUpdate]
+  );
 
   const sortieLocalTiming = useMemo(() => {
     if (!formData.date || !formData.time || !formData.time.includes(":")) {
@@ -323,11 +333,7 @@ export default function SortieInfo({ initialData, onUpdate }: SortieInfoProps) {
         <PositionInput
           rawValue={formData.route || ""}
           cachedPosition={formData.position ?? [null, null]}
-          onChange={(route, position) => {
-            const updated = { ...formData, route, position };
-            setFormData(updated);
-            onUpdate({ route, position });
-          }}
+          onChange={handlePositionChange}
         />
 
         <div className="space-y-2">

--- a/src/components/SortieInfo.tsx
+++ b/src/components/SortieInfo.tsx
@@ -3,6 +3,7 @@
 import { ChangeEvent, useEffect, useMemo, useState } from "react";
 import aircraftData from "@/data/aircraft.json";
 import type { WorksheetData } from "@/utils/types";
+import PositionInput from "@/components/PositionInput";
 
 interface SortieInfoProps {
   initialData?: WorksheetData;
@@ -19,6 +20,7 @@ type SortieInfoData = Pick<
   | "tailN"
   | "airport"
   | "route"
+  | "position"
   | "weight"
   | "altitude"
 >;
@@ -33,6 +35,7 @@ export default function SortieInfo({ initialData, onUpdate }: SortieInfoProps) {
     tailN: "",
     airport: ["", ""],
     route: "",
+    position: [null, null],
     weight: null,
     altitude: [null, null, null],
   });
@@ -317,19 +320,15 @@ export default function SortieInfo({ initialData, onUpdate }: SortieInfoProps) {
           />
         </div>
 
-        <div className="space-y-2">
-          <label htmlFor="route" className="block text-sm font-medium">
-            Area of Operations (position)
-          </label>
-          <input
-            type="text"
-            id="route"
-            name="route"
-            value={formData.route || ""}
-            onChange={handleInputChange}
-            className="w-full px-3 py-2 border rounded-md dark:bg-black/[.15] dark:border-white/[.145]"
-          />
-        </div>
+        <PositionInput
+          rawValue={formData.route || ""}
+          cachedPosition={formData.position ?? [null, null]}
+          onChange={(route, position) => {
+            const updated = { ...formData, route, position };
+            setFormData(updated);
+            onUpdate({ route, position });
+          }}
+        />
 
         <div className="space-y-2">
           <label htmlFor="operatingAltitude" className="block text-sm font-medium">

--- a/src/utils/__tests__/magvar.test.ts
+++ b/src/utils/__tests__/magvar.test.ts
@@ -1,0 +1,22 @@
+import { magneticVariation } from "../magvar";
+
+describe("magneticVariation", () => {
+  it("returns positive (east) declination in northern Utah", () => {
+    // Northern Utah magvar is positive ~10-11° east in current epoch.
+    const decl = magneticVariation(41.2, -112.0);
+    expect(decl).toBeGreaterThan(5);
+    expect(decl).toBeLessThan(15);
+  });
+
+  it("returns near-zero declination near agonic line (eastern US)", () => {
+    // Agonic line passes near 0°W on the eastern seaboard in current epoch.
+    const decl = magneticVariation(35, -83);
+    expect(Math.abs(decl)).toBeLessThan(8);
+  });
+
+  it("accepts an optional date parameter", () => {
+    const declNow = magneticVariation(40, -111, new Date());
+    expect(typeof declNow).toBe("number");
+    expect(Number.isFinite(declNow)).toBe(true);
+  });
+});

--- a/src/utils/__tests__/positionMath.test.ts
+++ b/src/utils/__tests__/positionMath.test.ts
@@ -1,0 +1,35 @@
+import { geodesicDestination } from "../positionMath";
+
+describe("geodesicDestination", () => {
+  it("travels east 60nm from (0, 0) ≈ (0, 1°)", () => {
+    const { lat, lon } = geodesicDestination(0, 0, 90, 60);
+    expect(lat).toBeCloseTo(0, 4);
+    expect(lon).toBeCloseTo(1.0, 2);
+  });
+
+  it("travels north 60nm from (0, 0) ≈ (1°, 0)", () => {
+    const { lat, lon } = geodesicDestination(0, 0, 0, 60);
+    expect(lat).toBeCloseTo(1.0, 2);
+    expect(lon).toBeCloseTo(0, 4);
+  });
+
+  it("zero distance returns starting point", () => {
+    const { lat, lon } = geodesicDestination(41.5, -112.5, 285, 0);
+    expect(lat).toBeCloseTo(41.5, 6);
+    expect(lon).toBeCloseTo(-112.5, 6);
+  });
+
+  it("normalizes longitude across antimeridian", () => {
+    // From near +180, traveling east, lon should wrap to negative.
+    const { lon } = geodesicDestination(0, 179, 90, 120);
+    expect(lon).toBeLessThan(0);
+    expect(lon).toBeGreaterThan(-180);
+  });
+
+  it("KOGD-like reference: (41.20, -112.01) + true bearing 297° + 34nm", () => {
+    // Hand-computed reference point — within 0.05° tolerance.
+    const { lat, lon } = geodesicDestination(41.2, -112.01, 297, 34);
+    expect(lat).toBeCloseTo(41.46, 1);
+    expect(lon).toBeCloseTo(-112.69, 1);
+  });
+});

--- a/src/utils/__tests__/positionMath.test.ts
+++ b/src/utils/__tests__/positionMath.test.ts
@@ -32,4 +32,16 @@ describe("geodesicDestination", () => {
     expect(lat).toBeCloseTo(41.46, 1);
     expect(lon).toBeCloseTo(-112.69, 1);
   });
+
+  it("returns finite latitude even when sinLat2 would round outside [-1, 1]", () => {
+    // Travelling 0° (due north) from (89.99, 0) for 90nm crosses the pole.
+    // Spherical formula puts sinLat2 right at +1 and floating-point error
+    // can push it past 1, which would make Math.asin return NaN without
+    // the clamp.
+    const { lat, lon } = geodesicDestination(89.99, 0, 0, 90);
+    expect(Number.isFinite(lat)).toBe(true);
+    expect(Number.isFinite(lon)).toBe(true);
+    expect(lat).toBeLessThanOrEqual(90);
+    expect(lat).toBeGreaterThanOrEqual(-90);
+  });
 });

--- a/src/utils/__tests__/positionParser.test.ts
+++ b/src/utils/__tests__/positionParser.test.ts
@@ -136,3 +136,74 @@ describe("parsePosition - DMS (degree-minute-second)", () => {
     expect(result.kind).toBe("unrecognized");
   });
 });
+
+describe("parsePosition - radial-distance", () => {
+  it("parses 4-letter ID as airport-rd", () => {
+    const result = parsePosition("KOGD/285/34");
+    expect(result.kind).toBe("airport-rd");
+    if (result.kind === "airport-rd") {
+      expect(result.stationId).toBe("KOGD");
+      expect(result.radial).toBe(285);
+      expect(result.distanceNm).toBe(34);
+    }
+  });
+
+  it("parses 3-letter ID as vor-rd", () => {
+    const result = parsePosition("OGD/285/34");
+    expect(result.kind).toBe("vor-rd");
+    if (result.kind === "vor-rd") {
+      expect(result.stationId).toBe("OGD");
+      expect(result.radial).toBe(285);
+      expect(result.distanceNm).toBe(34);
+    }
+  });
+
+  it("uppercases lowercase station id", () => {
+    const result = parsePosition("kogd/285/34");
+    expect(result.kind).toBe("airport-rd");
+    if (result.kind === "airport-rd") {
+      expect(result.stationId).toBe("KOGD");
+    }
+  });
+
+  it("accepts decimal distance", () => {
+    const result = parsePosition("KOGD/285/34.5");
+    expect(result.kind).toBe("airport-rd");
+    if (result.kind === "airport-rd") {
+      expect(result.distanceNm).toBe(34.5);
+    }
+  });
+
+  it("rejects radial of fewer than 3 digits", () => {
+    const result = parsePosition("KOGD/85/34");
+    expect(result.kind).toBe("unrecognized");
+  });
+
+  it("rejects radial > 360", () => {
+    const result = parsePosition("KOGD/400/34");
+    expect(result.kind).toBe("unrecognized");
+  });
+
+  it("rejects distance > 500 nm", () => {
+    const result = parsePosition("KOGD/285/600");
+    expect(result.kind).toBe("unrecognized");
+  });
+
+  it("rejects negative distance", () => {
+    const result = parsePosition("KOGD/285/-5");
+    expect(result.kind).toBe("unrecognized");
+  });
+
+  it("accepts zero distance", () => {
+    const result = parsePosition("KOGD/285/0");
+    expect(result.kind).toBe("airport-rd");
+    if (result.kind === "airport-rd") {
+      expect(result.distanceNm).toBe(0);
+    }
+  });
+
+  it("ignores 5-letter station id", () => {
+    const result = parsePosition("ABCDE/285/34");
+    expect(result.kind).toBe("unrecognized");
+  });
+});

--- a/src/utils/__tests__/positionParser.test.ts
+++ b/src/utils/__tests__/positionParser.test.ts
@@ -99,3 +99,40 @@ describe("parsePosition - DDM (degree-decimal-minutes)", () => {
     expect(result.kind).toBe("unrecognized");
   });
 });
+
+describe("parsePosition - DMS (degree-minute-second)", () => {
+  it("parses DMS with letters", () => {
+    const result = parsePosition("360051N/0753004W");
+    expect(result.kind).toBe("dms");
+    if (result.kind === "dms") {
+      // 36 + 0/60 + 51/3600 = 36.01416...  → 36.0142
+      expect(result.lat).toBe(36.0142);
+      // -(75 + 30/60 + 4/3600) = -75.50111... → -75.5011
+      expect(result.lon).toBe(-75.5011);
+    }
+  });
+
+  it("parses DMS with minus", () => {
+    const result = parsePosition("360051/-0753004");
+    expect(result.kind).toBe("dms");
+    if (result.kind === "dms") {
+      expect(result.lat).toBe(36.0142);
+      expect(result.lon).toBe(-75.5011);
+    }
+  });
+
+  it("rejects DMS with seconds >= 60", () => {
+    const result = parsePosition("360060N/0753004W");
+    expect(result.kind).toBe("unrecognized");
+  });
+
+  it("rejects DMS with minutes >= 60", () => {
+    const result = parsePosition("366000N/0753004W");
+    expect(result.kind).toBe("unrecognized");
+  });
+
+  it("rejects DMS with latitude > 90", () => {
+    const result = parsePosition("910000N/0753004W");
+    expect(result.kind).toBe("unrecognized");
+  });
+});

--- a/src/utils/__tests__/positionParser.test.ts
+++ b/src/utils/__tests__/positionParser.test.ts
@@ -67,3 +67,35 @@ describe("parsePosition - decimal formats", () => {
     expect(result.raw).toBe("Cache Valley");
   });
 });
+
+describe("parsePosition - DDM (degree-decimal-minutes)", () => {
+  it("parses DDM with letters", () => {
+    const result = parsePosition("3600.86N/07530.07W");
+    expect(result.kind).toBe("ddm");
+    if (result.kind === "ddm") {
+      // 36 + 0.86/60 = 36.0143...
+      expect(result.lat).toBe(36.0143);
+      // 75 + 30.07/60 = 75.5012... (negated)
+      expect(result.lon).toBe(-75.5012);
+    }
+  });
+
+  it("parses DDM with minus", () => {
+    const result = parsePosition("3600.86/-07530.07");
+    expect(result.kind).toBe("ddm");
+    if (result.kind === "ddm") {
+      expect(result.lat).toBe(36.0143);
+      expect(result.lon).toBe(-75.5012);
+    }
+  });
+
+  it("rejects DDM with minutes >= 60", () => {
+    const result = parsePosition("3660.00N/07530.07W");
+    expect(result.kind).toBe("unrecognized");
+  });
+
+  it("rejects DDM with degrees out of range", () => {
+    const result = parsePosition("9100.00N/07530.07W");
+    expect(result.kind).toBe("unrecognized");
+  });
+});

--- a/src/utils/__tests__/positionParser.test.ts
+++ b/src/utils/__tests__/positionParser.test.ts
@@ -1,0 +1,69 @@
+import { parsePosition } from "../positionParser";
+
+describe("parsePosition - decimal formats", () => {
+  it("parses DD.dd with N/W letters", () => {
+    const result = parsePosition("36.01N/75.50W");
+    expect(result.kind).toBe("decimal");
+    if (result.kind === "decimal") {
+      expect(result.lat).toBe(36.01);
+      expect(result.lon).toBe(-75.5);
+    }
+  });
+
+  it("parses DD.dd with S/E letters", () => {
+    const result = parsePosition("36.01S/75.50E");
+    expect(result.kind).toBe("decimal");
+    if (result.kind === "decimal") {
+      expect(result.lat).toBe(-36.01);
+      expect(result.lon).toBe(75.5);
+    }
+  });
+
+  it("parses DD.dd with minus signs", () => {
+    const result = parsePosition("36.01/-75.50");
+    expect(result.kind).toBe("decimal");
+    if (result.kind === "decimal") {
+      expect(result.lat).toBe(36.01);
+      expect(result.lon).toBe(-75.5);
+    }
+  });
+
+  it("accepts comma + space separator for decimal-with-minus", () => {
+    const result = parsePosition("41.4321, -112.7042");
+    expect(result.kind).toBe("decimal");
+    if (result.kind === "decimal") {
+      expect(result.lat).toBe(41.4321);
+      expect(result.lon).toBe(-112.7042);
+    }
+  });
+
+  it("rounds to 4 decimal places", () => {
+    const result = parsePosition("36.123456N/75.987654W");
+    expect(result.kind).toBe("decimal");
+    if (result.kind === "decimal") {
+      expect(result.lat).toBe(36.1235);
+      expect(result.lon).toBe(-75.9877);
+    }
+  });
+
+  it("rejects out-of-range latitude", () => {
+    const result = parsePosition("91.00N/75.50W");
+    expect(result.kind).toBe("unrecognized");
+  });
+
+  it("rejects out-of-range longitude", () => {
+    const result = parsePosition("36.01N/181.00W");
+    expect(result.kind).toBe("unrecognized");
+  });
+
+  it("preserves raw input on success", () => {
+    const result = parsePosition("36.01N/75.50W");
+    expect(result.raw).toBe("36.01N/75.50W");
+  });
+
+  it("preserves raw input on unrecognized", () => {
+    const result = parsePosition("Cache Valley");
+    expect(result.kind).toBe("unrecognized");
+    expect(result.raw).toBe("Cache Valley");
+  });
+});

--- a/src/utils/__tests__/urlState.test.ts
+++ b/src/utils/__tests__/urlState.test.ts
@@ -429,4 +429,32 @@ describe("deserializeState", () => {
     const restored = deserializeState(serialized, initialState);
     expect(restored.wind).toEqual(originalState.wind);
   });
+
+  describe("position field", () => {
+    it("should round-trip position field as length-2 number array", () => {
+      const initial = {
+        route: "",
+        position: [null, null] as [number | null, number | null],
+      };
+      const state = {
+        ...initial,
+        route: "KOGD/285/34",
+        position: [41.4321, -112.7042] as [number | null, number | null],
+      };
+      const serialized = serializeState(state);
+      const deserialized = deserializeState(serialized, initial);
+      expect(deserialized.position).toEqual([41.4321, -112.7042]);
+      expect(deserialized.route).toBe("KOGD/285/34");
+    });
+
+    it("should omit position field from URL when both values are null", () => {
+      const initial = {
+        route: "",
+        position: [null, null] as [number | null, number | null],
+      };
+      const state = { ...initial, position: [null, null] as [number | null, number | null] };
+      const serialized = serializeState(state);
+      expect(serialized).not.toContain("position");
+    });
+  });
 });

--- a/src/utils/aviationWeatherApi.test.ts
+++ b/src/utils/aviationWeatherApi.test.ts
@@ -6,6 +6,7 @@ import {
   getMETAR,
   getTAF,
   getAirportInfo,
+  getNavaidInfo,
   getWindTemp,
   getWeatherDataBatch,
   debouncedRequest,
@@ -13,6 +14,7 @@ import {
   type METARResponse,
   type TAFResponse,
   type AirportResponse,
+  type NavaidResponse,
   type WindTempResponse,
 } from "./aviationWeatherApi";
 
@@ -199,6 +201,55 @@ describe("Aviation Weather API", () => {
       );
 
       expect(result).toEqual(mockAirportResponse);
+    });
+  });
+
+  describe("getNavaidInfo", () => {
+    const mockNavaidResponse: NavaidResponse[] = [
+      {
+        id: "OGD",
+        name: "Ogden VOR",
+        lat: 41.5,
+        lon: -112.76,
+        type: "VOR-DME",
+        magvar: 11.5,
+      },
+    ];
+
+    it("calls the navaid endpoint with comma-joined ids", async () => {
+      (fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockNavaidResponse,
+      });
+
+      const result = await getNavaidInfo(["OGD", "DTA"]);
+
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining("/api/aviation-weather?endpoint=navaid"),
+        expect.objectContaining({
+          method: "GET",
+          headers: {
+            Accept: "application/json",
+            "User-Agent": "Mountain-Worksheet/1.0",
+          },
+        })
+      );
+
+      const calledUrl = (fetch as jest.Mock).mock.calls[0][0] as string;
+      expect(calledUrl).toContain("ids=OGD%2CDTA");
+      expect(result).toEqual(mockNavaidResponse);
+    });
+
+    it("propagates 404 as APIError", async () => {
+      (fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        text: async () => "Not Found",
+      });
+
+      await expect(getNavaidInfo(["XXX"])).rejects.toThrow(
+        "Not Found - Airport or data not available"
+      );
     });
   });
 

--- a/src/utils/aviationWeatherApi.test.ts
+++ b/src/utils/aviationWeatherApi.test.ts
@@ -97,7 +97,7 @@ describe("Aviation Weather API", () => {
       });
 
       await expect(getMETAR(["INVALID"], 1, 0)).rejects.toThrow(
-        "Not Found - Airport or data not available"
+        "Not Found - Resource or data not available"
       );
     });
   });
@@ -240,16 +240,19 @@ describe("Aviation Weather API", () => {
       expect(result).toEqual(mockNavaidResponse);
     });
 
-    it("propagates 404 as APIError", async () => {
+    it("propagates 404 as APIError with code 404", async () => {
       (fetch as jest.Mock).mockResolvedValueOnce({
         ok: false,
         status: 404,
         text: async () => "Not Found",
       });
 
-      await expect(getNavaidInfo(["XXX"])).rejects.toThrow(
-        "Not Found - Airport or data not available"
-      );
+      // Assert on type and code rather than message text, since the error
+      // text is shared across endpoints and may change over time.
+      await expect(getNavaidInfo(["XXX"])).rejects.toMatchObject({
+        name: "APIError",
+        code: 404,
+      });
     });
   });
 
@@ -445,7 +448,7 @@ describe("Aviation Weather API", () => {
       });
 
       await expect(getMETAR(["INVALID"], 1, 0)).rejects.toThrow(
-        "Not Found - Airport or data not available"
+        "Not Found - Resource or data not available"
       );
       expect(fetch).toHaveBeenCalledTimes(1);
     });

--- a/src/utils/aviationWeatherApi.ts
+++ b/src/utils/aviationWeatherApi.ts
@@ -213,7 +213,7 @@ async function makeApiRequest<T>(
         case 404:
           throw new APIError({
             code: 404,
-            message: "Not Found - Airport or data not available",
+            message: "Not Found - Resource or data not available",
             details: await response.text(),
           });
         case 429:

--- a/src/utils/aviationWeatherApi.ts
+++ b/src/utils/aviationWeatherApi.ts
@@ -98,6 +98,15 @@ export interface RunwayInfo {
   closed: boolean;
 }
 
+export interface NavaidResponse {
+  id: string;
+  name?: string;
+  lat: number;
+  lon: number;
+  type?: string; // e.g., "VOR", "VOR-DME", "VORTAC", "NDB"
+  magvar?: number; // station declination, if exposed
+}
+
 export interface WindTempResponse {
   icaoId: string;
   validTime: string;
@@ -296,6 +305,20 @@ export async function getAirportInfo(
   };
 
   return makeApiRequest<AirportResponse[]>("airport", params);
+}
+
+/**
+ * Get navaid (VOR/NDB/etc.) information by ID.
+ */
+export async function getNavaidInfo(
+  ids: string[]
+): Promise<NavaidResponse[]> {
+  const params = {
+    ids: ids.join(","),
+    format: "json",
+  };
+
+  return makeApiRequest<NavaidResponse[]>("navaid", params);
 }
 
 /**

--- a/src/utils/magvar.ts
+++ b/src/utils/magvar.ts
@@ -1,0 +1,17 @@
+import geomagnetism from "geomagnetism";
+
+/**
+ * Magnetic variation (declination) at a point.
+ * Returns east-positive degrees: trueBearing = magneticBearing + variation.
+ *
+ * Uses the World Magnetic Model via the `geomagnetism` package.
+ */
+export function magneticVariation(
+  lat: number,
+  lon: number,
+  date: Date = new Date()
+): number {
+  const model = geomagnetism.model(date);
+  const point = model.point([lat, lon]);
+  return point.decl;
+}

--- a/src/utils/positionMath.ts
+++ b/src/utils/positionMath.ts
@@ -1,0 +1,34 @@
+const EARTH_RADIUS_NM = 3440.065;
+const toRad = (d: number): number => (d * Math.PI) / 180;
+const toDeg = (r: number): number => (r * 180) / Math.PI;
+
+/**
+ * Spherical-earth direct geodesic.
+ * Given a start lat/lon, a TRUE bearing (degrees, clockwise from north),
+ * and a distance in nautical miles, returns the destination lat/lon.
+ */
+export function geodesicDestination(
+  startLat: number,
+  startLon: number,
+  trueBearingDeg: number,
+  distanceNm: number
+): { lat: number; lon: number } {
+  const angularDistance = distanceNm / EARTH_RADIUS_NM;
+  const lat1 = toRad(startLat);
+  const lon1 = toRad(startLon);
+  const brng = toRad(trueBearingDeg);
+
+  const sinLat2 =
+    Math.sin(lat1) * Math.cos(angularDistance) +
+    Math.cos(lat1) * Math.sin(angularDistance) * Math.cos(brng);
+  const lat2 = Math.asin(sinLat2);
+
+  const y = Math.sin(brng) * Math.sin(angularDistance) * Math.cos(lat1);
+  const x = Math.cos(angularDistance) - Math.sin(lat1) * sinLat2;
+  const lon2 = lon1 + Math.atan2(y, x);
+
+  // Normalize longitude to [-180, 180]
+  const lon2Norm = ((toDeg(lon2) + 540) % 360) - 180;
+
+  return { lat: toDeg(lat2), lon: lon2Norm };
+}

--- a/src/utils/positionMath.ts
+++ b/src/utils/positionMath.ts
@@ -18,9 +18,12 @@ export function geodesicDestination(
   const lon1 = toRad(startLon);
   const brng = toRad(trueBearingDeg);
 
-  const sinLat2 =
+  const sinLat2Raw =
     Math.sin(lat1) * Math.cos(angularDistance) +
     Math.cos(lat1) * Math.sin(angularDistance) * Math.cos(brng);
+  // Clamp to [-1, 1] to absorb floating-point drift that would otherwise
+  // make Math.asin return NaN near the poles or for long legs.
+  const sinLat2 = Math.max(-1, Math.min(1, sinLat2Raw));
   const lat2 = Math.asin(sinLat2);
 
   const y = Math.sin(brng) * Math.sin(angularDistance) * Math.cos(lat1);

--- a/src/utils/positionParser.ts
+++ b/src/utils/positionParser.ts
@@ -65,10 +65,51 @@ const tryDdmMinus = (s: string): { lat: number; lon: number } | null => {
   return { lat: round4(lat), lon: round4(lon) };
 };
 
+const dmsFromParts = (degStr: string, minStr: string, secStr: string): number | null => {
+  const deg = Number(degStr);
+  const min = Number(minStr);
+  const sec = Number(secStr);
+  if (!Number.isFinite(deg) || !Number.isFinite(min) || !Number.isFinite(sec)) return null;
+  if (min < 0 || min >= 60) return null;
+  if (sec < 0 || sec >= 60) return null;
+  return deg + min / 60 + sec / 3600;
+};
+
+const tryDmsLetters = (s: string): { lat: number; lon: number } | null => {
+  // DDMMSS for lat (6 digits), DDDMMSS for lon (7 digits)
+  const m = s.match(/^(\d{2})(\d{2})(\d{2})([NS])\/(\d{3})(\d{2})(\d{2})([EW])$/);
+  if (!m) return null;
+  const latVal = dmsFromParts(m[1], m[2], m[3]);
+  const lonVal = dmsFromParts(m[5], m[6], m[7]);
+  if (latVal === null || lonVal === null) return null;
+  const lat = latVal * (m[4] === "S" ? -1 : 1);
+  const lon = lonVal * (m[8] === "W" ? -1 : 1);
+  if (!inRange(lat, lon)) return null;
+  return { lat: round4(lat), lon: round4(lon) };
+};
+
+const tryDmsMinus = (s: string): { lat: number; lon: number } | null => {
+  const m = s.match(/^(\d{2})(\d{2})(\d{2})\/(-?)(\d{3})(\d{2})(\d{2})$/);
+  if (!m) return null;
+  const latVal = dmsFromParts(m[1], m[2], m[3]);
+  const lonVal = dmsFromParts(m[5], m[6], m[7]);
+  if (latVal === null || lonVal === null) return null;
+  const lat = latVal;
+  const lon = lonVal * (m[4] === "-" ? -1 : 1);
+  if (!inRange(lat, lon)) return null;
+  return { lat: round4(lat), lon: round4(lon) };
+};
+
 export function parsePosition(input: string): ParsedPosition {
   const raw = input;
   const s = input.trim().toUpperCase();
   if (s === "") return { kind: "unrecognized", raw };
+
+  const dmsL = tryDmsLetters(s);
+  if (dmsL) return { kind: "dms", raw, ...dmsL };
+
+  const dmsM = tryDmsMinus(s);
+  if (dmsM) return { kind: "dms", raw, ...dmsM };
 
   const ddmL = tryDdmLetters(s);
   if (ddmL) return { kind: "ddm", raw, ...ddmL };

--- a/src/utils/positionParser.ts
+++ b/src/utils/positionParser.ts
@@ -1,0 +1,47 @@
+export type ParsedPosition =
+  | { kind: "decimal";      raw: string; lat: number; lon: number }
+  | { kind: "dms";          raw: string; lat: number; lon: number }
+  | { kind: "ddm";          raw: string; lat: number; lon: number }
+  | { kind: "airport-rd";   raw: string; stationId: string; radial: number; distanceNm: number }
+  | { kind: "vor-rd";       raw: string; stationId: string; radial: number; distanceNm: number }
+  | { kind: "unrecognized"; raw: string };
+
+const round4 = (n: number): number => Math.round(n * 10000) / 10000;
+
+const inRange = (lat: number, lon: number): boolean =>
+  lat >= -90 && lat <= 90 && lon >= -180 && lon <= 180;
+
+const tryDecimalLetters = (s: string): { lat: number; lon: number } | null => {
+  const m = s.match(/^([\d.]+)([NS])\/([\d.]+)([EW])$/);
+  if (!m) return null;
+  const lat = Number(m[1]) * (m[2] === "S" ? -1 : 1);
+  const lon = Number(m[3]) * (m[4] === "W" ? -1 : 1);
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null;
+  if (!inRange(lat, lon)) return null;
+  return { lat: round4(lat), lon: round4(lon) };
+};
+
+const tryDecimalMinus = (s: string): { lat: number; lon: number } | null => {
+  // Accept either `/` or `,` (with optional whitespace) as separator
+  const m = s.match(/^(-?[\d.]+)\s*[/,]\s*(-?[\d.]+)$/);
+  if (!m) return null;
+  const lat = Number(m[1]);
+  const lon = Number(m[2]);
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null;
+  if (!inRange(lat, lon)) return null;
+  return { lat: round4(lat), lon: round4(lon) };
+};
+
+export function parsePosition(input: string): ParsedPosition {
+  const raw = input;
+  const s = input.trim().toUpperCase();
+  if (s === "") return { kind: "unrecognized", raw };
+
+  const letters = tryDecimalLetters(s);
+  if (letters) return { kind: "decimal", raw, ...letters };
+
+  const minus = tryDecimalMinus(s);
+  if (minus) return { kind: "decimal", raw, ...minus };
+
+  return { kind: "unrecognized", raw };
+}

--- a/src/utils/positionParser.ts
+++ b/src/utils/positionParser.ts
@@ -32,16 +32,55 @@ const tryDecimalMinus = (s: string): { lat: number; lon: number } | null => {
   return { lat: round4(lat), lon: round4(lon) };
 };
 
+const ddmFromParts = (degStr: string, minStr: string): number | null => {
+  const deg = Number(degStr);
+  const min = Number(minStr);
+  if (!Number.isFinite(deg) || !Number.isFinite(min)) return null;
+  if (min < 0 || min >= 60) return null;
+  return deg + min / 60;
+};
+
+const tryDdmLetters = (s: string): { lat: number; lon: number } | null => {
+  // \d{2}\d{2}\.\d+ for lat (DDMM.mm), \d{3}\d{2}\.\d+ for lon (DDDMM.mm)
+  const m = s.match(/^(\d{2})(\d{2}\.\d+)([NS])\/(\d{3})(\d{2}\.\d+)([EW])$/);
+  if (!m) return null;
+  const latVal = ddmFromParts(m[1], m[2]);
+  const lonVal = ddmFromParts(m[4], m[5]);
+  if (latVal === null || lonVal === null) return null;
+  const lat = latVal * (m[3] === "S" ? -1 : 1);
+  const lon = lonVal * (m[6] === "W" ? -1 : 1);
+  if (!inRange(lat, lon)) return null;
+  return { lat: round4(lat), lon: round4(lon) };
+};
+
+const tryDdmMinus = (s: string): { lat: number; lon: number } | null => {
+  const m = s.match(/^(\d{2})(\d{2}\.\d+)\/(-?)(\d{3})(\d{2}\.\d+)$/);
+  if (!m) return null;
+  const latVal = ddmFromParts(m[1], m[2]);
+  const lonVal = ddmFromParts(m[4], m[5]);
+  if (latVal === null || lonVal === null) return null;
+  const lat = latVal;
+  const lon = lonVal * (m[3] === "-" ? -1 : 1);
+  if (!inRange(lat, lon)) return null;
+  return { lat: round4(lat), lon: round4(lon) };
+};
+
 export function parsePosition(input: string): ParsedPosition {
   const raw = input;
   const s = input.trim().toUpperCase();
   if (s === "") return { kind: "unrecognized", raw };
 
-  const letters = tryDecimalLetters(s);
-  if (letters) return { kind: "decimal", raw, ...letters };
+  const ddmL = tryDdmLetters(s);
+  if (ddmL) return { kind: "ddm", raw, ...ddmL };
 
-  const minus = tryDecimalMinus(s);
-  if (minus) return { kind: "decimal", raw, ...minus };
+  const ddmM = tryDdmMinus(s);
+  if (ddmM) return { kind: "ddm", raw, ...ddmM };
+
+  const decL = tryDecimalLetters(s);
+  if (decL) return { kind: "decimal", raw, ...decL };
+
+  const decM = tryDecimalMinus(s);
+  if (decM) return { kind: "decimal", raw, ...decM };
 
   return { kind: "unrecognized", raw };
 }

--- a/src/utils/positionParser.ts
+++ b/src/utils/positionParser.ts
@@ -100,10 +100,28 @@ const tryDmsMinus = (s: string): { lat: number; lon: number } | null => {
   return { lat: round4(lat), lon: round4(lon) };
 };
 
+const tryRadialDistance = (
+  s: string
+): { kind: "airport-rd" | "vor-rd"; stationId: string; radial: number; distanceNm: number } | null => {
+  // Letters 3 or 4, slash, exactly 3-digit radial, slash, distance (int or decimal)
+  const m = s.match(/^([A-Z]{3,4})\/(\d{3})\/(\d+(?:\.\d+)?)$/);
+  if (!m) return null;
+  const stationId = m[1];
+  const radial = Number(m[2]);
+  const distanceNm = Number(m[3]);
+  if (radial < 0 || radial > 360) return null;
+  if (distanceNm < 0 || distanceNm > 500) return null;
+  const kind = stationId.length === 4 ? "airport-rd" : "vor-rd";
+  return { kind, stationId, radial, distanceNm };
+};
+
 export function parsePosition(input: string): ParsedPosition {
   const raw = input;
   const s = input.trim().toUpperCase();
   if (s === "") return { kind: "unrecognized", raw };
+
+  const rd = tryRadialDistance(s);
+  if (rd) return { ...rd, raw };
 
   const dmsL = tryDmsLetters(s);
   if (dmsL) return { kind: "dms", raw, ...dmsL };

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -11,6 +11,7 @@ export interface WorksheetData {
   tailN: string;
   airport: [string, string]; // [departure, arrival]
   route: string; // Area of Operations/Route
+  position: [number | null, number | null]; // [lat, lon] in DD.dddd; [null, null] when unset
 
   // Weather Information
   wind: [(number | null)[], (number | null)[], (number | null)[]]; // [wDir, wVel, temp] arrays for each altitude


### PR DESCRIPTION
## Summary

Closes #90. The "Area of Operations (position)" field now accepts all eight ForeFlight position formats and resolves them to canonical decimal-degree coordinates:

- DD.dd with letters (`36.01N/75.50W`) and minus (`36.01/-75.50`) — also accepts comma-separated decimals (`41.43, -112.70`)
- DMS (`360051N/0753004W`, `360051/-0753004`)
- DDM (`3600.86N/07530.07W`, `3600.86/-07530.07`)
- Airport ID/radial/distance (`KOGD/285/34`) — looks up via aviationweather.gov airport endpoint
- VOR ID/radial/distance (`OGD/285/34`) — looks up via the navaid endpoint

Magnetic radials are converted to true bearings via the World Magnetic Model (`geomagnetism` package). Resolved coordinates are cached in URL state so reloaded URLs don't re-fetch. Free-text input (e.g., "Cache Valley") is preserved with a small "unrecognized format" hint.

## Architecture

- `src/utils/positionParser.ts` — pure synchronous parser, returns a discriminated union per kind.
- `src/utils/positionMath.ts` — spherical-earth direct geodesic.
- `src/utils/magvar.ts` — thin wrapper over the WMM.
- `src/utils/aviationWeatherApi.ts` — adds `getNavaidInfo`.
- `src/components/PositionInput.tsx` — owns the input/lookup state machine (debounce, race protection via request-id ref, module-scoped session cache).
- `src/components/SortieInfo.tsx` — replaces the inline route input with `PositionInput`.

Spec: `docs/superpowers/specs/2026-05-09-position-intelligence-design.md`
Plan: `docs/superpowers/plans/2026-05-09-position-intelligence.md`

## Test Plan

- [x] 394 unit + component tests pass (`npm test`)
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [ ] Manual browser verification of each format (run `npm run dev`):
  - [x] `36.01N/75.50W` → `36.0100, -75.5000`
  - [x] `36.01/-75.50` → `36.0100, -75.5000`
  - [x] `41.4321, -112.7042` → `41.4321, -112.7042`
  - [x] `360051N/0753004W` → `36.0142, -75.5011`
  - [x] `360051/-0753004` → `36.0142, -75.5011`
  - [x] `3600.86N/07530.07W` → `36.0143, -75.5012`
  - [x] `3600.86/-07530.07` → `36.0143, -75.5012`
  - [x] `KOGD/285/34` → loading hint, then resolved coords
  - [x] `OGD/285/34` → loading hint, then resolved coords
  - [x] `Cache Valley` → "Unrecognized format" warning, free-text saved
  - [x] Reload URL with airport-rd; resolved coords appear without a network re-fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)