### PR TITLE
Issue #56 (3/3): G-AIRMET auto-flag for turb / cielVis / mtnObsc

### DIFF
--- a/src/components/WeatherDataIntegration.test.tsx
+++ b/src/components/WeatherDataIntegration.test.tsx
@@ -13,6 +13,7 @@ jest.mock("@/utils/aviationWeatherApi");
 jest.mock("@/utils/weatherDataMapper");
 jest.mock("@/utils/openMeteoApi");
 jest.mock("@/utils/areaOfOpsWeather");
+jest.mock("@/utils/gairmetApi");
 
 // Mock functions are available but not used in simplified tests
 const mockIsApiPopulatedData = isApiPopulatedData as jest.MockedFunction<

--- a/src/components/WeatherDataIntegration.test.tsx
+++ b/src/components/WeatherDataIntegration.test.tsx
@@ -139,4 +139,137 @@ describe("WeatherDataIntegration", () => {
       expect(screen.getByText(/forecast unavailable/i)).toBeInTheDocument();
     });
   });
+
+  it("emits skipped warning when opPos is unavailable", async () => {
+    const { mapWeatherDataToWorksheet, mergeWeatherData, isApiPopulatedData } =
+      jest.requireMock("@/utils/weatherDataMapper");
+    let capturedAreaOfOps: unknown = null;
+    mapWeatherDataToWorksheet.mockImplementation(
+      (_apiData: unknown, areaOfOps: unknown) => {
+        capturedAreaOfOps = areaOfOps;
+        return { success: true, data: {}, errors: [], warnings: [] };
+      }
+    );
+    mergeWeatherData.mockImplementation((existing: object, api: object) => ({
+      ...existing,
+      ...api,
+    }));
+    isApiPopulatedData.mockReturnValue({
+      wind: false,
+      temperature: false,
+      pressure: false,
+      runway: false,
+      altitude: false,
+    });
+    const { getWeatherDataBatch } = jest.requireMock("@/utils/aviationWeatherApi");
+    getWeatherDataBatch.mockResolvedValue({
+      metar: [],
+      taf: [],
+      airport: [],
+    });
+
+    const propsWithoutPosition = {
+      ...defaultProps,
+      worksheetData: { ...defaultProps.worksheetData, position: [null, null] as [number | null, number | null] },
+    };
+    render(<WeatherDataIntegration {...propsWithoutPosition} />);
+    fireEvent.click(screen.getByText("Fetch Weather"));
+
+    await waitFor(() => {
+      expect(mapWeatherDataToWorksheet).toHaveBeenCalled();
+    });
+    expect(capturedAreaOfOps).toMatchObject({
+      positionSource: "none",
+      warnings: expect.arrayContaining([
+        expect.stringMatching(/skipped/i),
+      ]),
+    });
+  });
+
+  it("continues pipeline when Open-Meteo fetch fails", async () => {
+    const { fetchPointForecast } = jest.requireMock("@/utils/openMeteoApi");
+    fetchPointForecast.mockRejectedValue(new Error("network down"));
+    const { mapWeatherDataToWorksheet, mergeWeatherData, isApiPopulatedData } =
+      jest.requireMock("@/utils/weatherDataMapper");
+    mapWeatherDataToWorksheet.mockReturnValue({
+      success: true,
+      data: { temp: [20, null, 22] },
+      errors: [],
+      warnings: [],
+    });
+    mergeWeatherData.mockImplementation((existing: object, api: object) => ({
+      ...existing,
+      ...api,
+    }));
+    isApiPopulatedData.mockReturnValue({
+      wind: false,
+      temperature: false,
+      pressure: false,
+      runway: false,
+      altitude: false,
+    });
+    const { getWeatherDataBatch } = jest.requireMock("@/utils/aviationWeatherApi");
+    getWeatherDataBatch.mockResolvedValue({
+      metar: [{ icaoId: "KORD", temp: 20, altim: 1015 }],
+      taf: [],
+      airport: [
+        { icaoId: "KORD", lat: 41.97, lon: -87.91 },
+        { icaoId: "KLAX", lat: 33.94, lon: -118.40 },
+      ],
+    });
+
+    const onDataUpdate = jest.fn();
+    render(<WeatherDataIntegration {...defaultProps} onDataUpdate={onDataUpdate} />);
+    fireEvent.click(screen.getByText("Fetch Weather"));
+
+    await waitFor(() => {
+      expect(onDataUpdate).toHaveBeenCalled();
+    });
+    // Pipeline ran despite Open-Meteo failure
+    expect(mapWeatherDataToWorksheet).toHaveBeenCalled();
+  });
+
+  it("continues pipeline when G-AIRMET fetch fails", async () => {
+    const { fetchGAirmets } = jest.requireMock("@/utils/gairmetApi");
+    fetchGAirmets.mockRejectedValue(new Error("gairmet network down"));
+    const { mapWeatherDataToWorksheet, mergeWeatherData, isApiPopulatedData } =
+      jest.requireMock("@/utils/weatherDataMapper");
+    let capturedAirmets: unknown = "unset";
+    mapWeatherDataToWorksheet.mockImplementation(
+      (_apiData: unknown, _areaOfOps: unknown, airmets: unknown) => {
+        capturedAirmets = airmets;
+        return { success: true, data: {}, errors: [], warnings: [] };
+      }
+    );
+    mergeWeatherData.mockImplementation((existing: object, api: object) => ({
+      ...existing,
+      ...api,
+    }));
+    isApiPopulatedData.mockReturnValue({
+      wind: false,
+      temperature: false,
+      pressure: false,
+      runway: false,
+      altitude: false,
+    });
+    const { getWeatherDataBatch } = jest.requireMock("@/utils/aviationWeatherApi");
+    getWeatherDataBatch.mockResolvedValue({
+      metar: [],
+      taf: [],
+      airport: [
+        { icaoId: "KORD", lat: 41.97, lon: -87.91 },
+        { icaoId: "KLAX", lat: 33.94, lon: -118.40 },
+      ],
+    });
+    const { fetchPointForecast } = jest.requireMock("@/utils/openMeteoApi");
+    fetchPointForecast.mockResolvedValue({ hourly: { time: [] } });
+
+    render(<WeatherDataIntegration {...defaultProps} />);
+    fireEvent.click(screen.getByText("Fetch Weather"));
+
+    await waitFor(() => {
+      expect(mapWeatherDataToWorksheet).toHaveBeenCalled();
+    });
+    expect(capturedAirmets).toBeNull();
+  });
 });

--- a/src/components/WeatherDataIntegration.tsx
+++ b/src/components/WeatherDataIntegration.tsx
@@ -169,35 +169,47 @@ export default function WeatherDataIntegration({
             : null;
 
         let areaOfOps: AreaOfOpsWeather | null = null;
+        let airmets: AirmetClassification | null = null;
         if (opPos) {
           const win = {
             start: new Date(midTime.getTime() - 24 * 3600 * 1000),
             end: new Date(midTime.getTime() + 24 * 3600 * 1000),
           };
-          try {
-            const raw = await fetchPointForecast(opPos[0], opPos[1], win);
+          const [pointResult, gairmetResult] = await Promise.allSettled([
+            fetchPointForecast(opPos[0], opPos[1], win),
+            fetchGAirmets(),
+          ]);
+          if (pointResult.status === "fulfilled") {
             areaOfOps = buildAreaOfOpsWeather({
               position: worksheetData.position ?? [null, null],
               depAirportLatLon,
               arrAirportLatLon,
               midTime,
               opAltitudeFt: worksheetData.altitude?.[1] ?? null,
-              raw,
+              raw: pointResult.value,
             });
-          } catch (err) {
-            console.warn("Open-Meteo fetch failed:", err);
+          } else {
+            console.warn("Open-Meteo fetch failed:", pointResult.reason);
+          }
+          if (gairmetResult.status === "fulfilled") {
+            airmets = classifyAirmets(gairmetResult.value, opPos, midTime);
+          } else {
+            console.warn("G-AIRMET fetch failed:", gairmetResult.reason);
           }
         }
 
-        // Fetch and classify G-AIRMETs
-        let airmets: AirmetClassification | null = null;
-        if (opPos) {
-          try {
-            const features = await fetchGAirmets();
-            airmets = classifyAirmets(features, opPos, midTime);
-          } catch (err) {
-            console.warn("G-AIRMET fetch failed:", err);
-          }
+        if (!opPos) {
+          // Build a minimal areaOfOps that only carries the warning, so it surfaces in the panel
+          areaOfOps = {
+            position: null,
+            positionSource: "none",
+            windsAloft: { direction: [null, null, null, null, null], speed: [null, null, null, null, null], temp: [null, null, null, null, null] },
+            opTemp: null,
+            opAltimeter: null,
+            warnings: [
+              "Operating area weather skipped: position and airport coordinates unavailable",
+            ],
+          };
         }
 
         // Map API data to worksheet format

--- a/src/components/WeatherDataIntegration.tsx
+++ b/src/components/WeatherDataIntegration.tsx
@@ -19,6 +19,11 @@ import {
   type AreaOfOpsWeather,
 } from "@/utils/areaOfOpsWeather";
 import {
+  fetchGAirmets,
+  classifyAirmets,
+  type AirmetClassification,
+} from "@/utils/gairmetApi";
+import {
   WeatherErrorModal,
   WeatherLoadingModal,
   AirportNotFoundModal,
@@ -184,15 +189,31 @@ export default function WeatherDataIntegration({
           }
         }
 
+        // Fetch and classify G-AIRMETs
+        let airmets: AirmetClassification | null = null;
+        if (opPos) {
+          try {
+            const features = await fetchGAirmets();
+            airmets = classifyAirmets(features, opPos, midTime);
+          } catch (err) {
+            console.warn("G-AIRMET fetch failed:", err);
+          }
+        }
+
         // Map API data to worksheet format
-        const mappingResult = mapWeatherDataToWorksheet(apiData, areaOfOps, {
-          flightDate: worksheetData.date!,
-          flightTime: worksheetData.time!,
-          durationHours: worksheetData.duration ?? null,
-          departureAirport,
-          arrivalAirport,
-          validateData: true,
-        });
+        const mappingResult = mapWeatherDataToWorksheet(
+          apiData,
+          areaOfOps,
+          airmets,
+          {
+            flightDate: worksheetData.date!,
+            flightTime: worksheetData.time!,
+            durationHours: worksheetData.duration ?? null,
+            departureAirport,
+            arrivalAirport,
+            validateData: true,
+          }
+        );
 
         if (!mappingResult.success) {
           throw new Error(

--- a/src/utils/__tests__/gairmetApi.test.ts
+++ b/src/utils/__tests__/gairmetApi.test.ts
@@ -65,7 +65,8 @@ describe("classifyAirmets", () => {
     expect(r.turb).toBe(true);
     expect(r.mtnObsc).toBe(true);
     expect(r.cielVis).toBe(true);
-    expect(r.warnings).toEqual([]);
+    // IFR threshold-mismatch note is always emitted when IFR is within threshold
+    expect(r.warnings.some((w) => /1000 ft \/ 3 sm/i.test(w))).toBe(true);
   });
 
   it("does not flag hazards whose polygon excludes the position", () => {
@@ -110,5 +111,23 @@ describe("classifyAirmets", () => {
       new Date("2026-06-01T00:00:00Z")
     );
     expect(r.warnings.some((w) => /unavailable/i.test(w))).toBe(true);
+  });
+
+  it("emits the IFR threshold-mismatch note whenever IFR was classified", () => {
+    const r = classifyAirmets(
+      [ifrAirmet],
+      [41, -112],
+      new Date("2026-05-12T16:00:00Z")
+    );
+    expect(r.warnings.some((w) => /1000 ft \/ 3 sm/i.test(w))).toBe(true);
+  });
+
+  it("does not emit the IFR threshold-mismatch note when no IFR AIRMET was within threshold", () => {
+    const r = classifyAirmets(
+      [turbAirmet],
+      [41, -112],
+      new Date("2026-05-12T16:00:00Z")
+    );
+    expect(r.warnings.some((w) => /1000 ft \/ 3 sm/i.test(w))).toBe(false);
   });
 });

--- a/src/utils/__tests__/gairmetApi.test.ts
+++ b/src/utils/__tests__/gairmetApi.test.ts
@@ -130,4 +130,29 @@ describe("classifyAirmets", () => {
     );
     expect(r.warnings.some((w) => /1000 ft \/ 3 sm/i.test(w))).toBe(false);
   });
+
+  it("clears flags to false when response has no TURB/IFR/MTN OBSC features", () => {
+    // e.g. only ICE / LLWS hazards present, or empty array. The fetch succeeded
+    // so we should clear stale flags rather than leave them via null sentinel.
+    const iceAirmet: GAirmetFeature = { ...turbAirmet, hazard: "ICE" };
+    const r = classifyAirmets(
+      [iceAirmet],
+      [41, -112],
+      new Date("2026-05-12T16:00:00Z")
+    );
+    expect(r.turb).toBe(false);
+    expect(r.cielVis).toBe(false);
+    expect(r.mtnObsc).toBe(false);
+  });
+
+  it("clears flags to false on an empty G-AIRMET response", () => {
+    const r = classifyAirmets(
+      [],
+      [41, -112],
+      new Date("2026-05-12T16:00:00Z")
+    );
+    expect(r.turb).toBe(false);
+    expect(r.cielVis).toBe(false);
+    expect(r.mtnObsc).toBe(false);
+  });
 });

--- a/src/utils/__tests__/gairmetApi.test.ts
+++ b/src/utils/__tests__/gairmetApi.test.ts
@@ -1,0 +1,114 @@
+import { pointInPolygon, classifyAirmets, type GAirmetFeature } from "../gairmetApi";
+
+describe("pointInPolygon", () => {
+  const square: [number, number][] = [
+    [40, -113],
+    [42, -113],
+    [42, -111],
+    [40, -111],
+    [40, -113],
+  ];
+
+  it("detects interior point", () => {
+    expect(pointInPolygon([41, -112], square)).toBe(true);
+  });
+
+  it("detects exterior point", () => {
+    expect(pointInPolygon([45, -112], square)).toBe(false);
+  });
+
+  it("works on concave polygon", () => {
+    const concave: [number, number][] = [
+      [0, 0],
+      [4, 0],
+      [4, 4],
+      [2, 2],
+      [0, 4],
+      [0, 0],
+    ];
+    // (1,3) is inside the concave bay's left lobe
+    expect(pointInPolygon([1, 3], concave)).toBe(true);
+    // (3, 3) is in the concave indent (above the (2,2) notch) — outside
+    expect(pointInPolygon([3, 3], concave)).toBe(false);
+  });
+});
+
+describe("classifyAirmets", () => {
+  const turbAirmet: GAirmetFeature = {
+    hazard: "TURB",
+    validTime: "2026-05-12T16:00:00.000Z",
+    forecastHour: 0,
+    geom: "AREA",
+    coords: [
+      { lat: "40", lon: "-113" },
+      { lat: "42", lon: "-113" },
+      { lat: "42", lon: "-111" },
+      { lat: "40", lon: "-111" },
+      { lat: "40", lon: "-113" },
+    ],
+  };
+  const mtnObscAirmet: GAirmetFeature = {
+    ...turbAirmet,
+    hazard: "MTN OBSC",
+  };
+  const ifrAirmet: GAirmetFeature = {
+    ...turbAirmet,
+    hazard: "IFR",
+  };
+
+  it("flags hazards whose polygon contains the position", () => {
+    const r = classifyAirmets(
+      [turbAirmet, mtnObscAirmet, ifrAirmet],
+      [41, -112],
+      new Date("2026-05-12T16:00:00Z")
+    );
+    expect(r.turb).toBe(true);
+    expect(r.mtnObsc).toBe(true);
+    expect(r.cielVis).toBe(true);
+    expect(r.warnings).toEqual([]);
+  });
+
+  it("does not flag hazards whose polygon excludes the position", () => {
+    const r = classifyAirmets(
+      [turbAirmet, mtnObscAirmet],
+      [50, -100],
+      new Date("2026-05-12T16:00:00Z")
+    );
+    expect(r.turb).toBe(false);
+    expect(r.mtnObsc).toBe(false);
+    expect(r.cielVis).toBe(false);
+  });
+
+  it("filters AIRMETs by validTime closest to midTime", () => {
+    const closer: GAirmetFeature = {
+      ...turbAirmet,
+      validTime: "2026-05-12T16:00:00.000Z",
+    };
+    const farther: GAirmetFeature = {
+      ...turbAirmet,
+      validTime: "2026-05-12T22:00:00.000Z",
+      coords: [
+        { lat: "0", lon: "0" },
+        { lat: "1", lon: "0" },
+        { lat: "1", lon: "1" },
+        { lat: "0", lon: "1" },
+        { lat: "0", lon: "0" },
+      ],
+    };
+    const r = classifyAirmets(
+      [closer, farther],
+      [41, -112],
+      new Date("2026-05-12T16:00:00Z")
+    );
+    expect(r.turb).toBe(true);
+  });
+
+  it("warns when no AIRMET set within 3 hr of midTime", () => {
+    const r = classifyAirmets(
+      [turbAirmet],
+      [41, -112],
+      new Date("2026-06-01T00:00:00Z")
+    );
+    expect(r.warnings.some((w) => /unavailable/i.test(w))).toBe(true);
+  });
+});

--- a/src/utils/gairmetApi.ts
+++ b/src/utils/gairmetApi.ts
@@ -66,11 +66,12 @@ export function classifyAirmets(
   const eligible = features.filter((f) =>
     ["TURB", "IFR", "MTN OBSC"].includes(f.hazard)
   );
+  // Fetch succeeded but the response carries no TURB/IFR/MTN OBSC features at
+  // all → no relevant hazards. Clear the flags rather than leaving stale state.
+  // (Genuine unavailability — fetch failure or no features in the time window
+  // — is signaled with null sentinels below.)
   if (eligible.length === 0) {
-    warnings.push(
-      `G-AIRMET data unavailable for ${midTime.toISOString()}; turb / cielVis / mtnObsc flags not updated`
-    );
-    return { turb: null, cielVis: null, mtnObsc: null, warnings };
+    return { turb: false, cielVis: false, mtnObsc: false, warnings };
   }
 
   // Group by hazard

--- a/src/utils/gairmetApi.ts
+++ b/src/utils/gairmetApi.ts
@@ -89,6 +89,7 @@ export function classifyAirmets(
   };
 
   let anyWithinThreshold = false;
+  let ifrWithinThreshold = false;
   for (const [hazard, list] of byHazard.entries()) {
     // Sort by abs delta from midTime; pick closest validTime
     const sorted = [...list].sort(
@@ -99,6 +100,7 @@ export function classifyAirmets(
     const bestDelta = Math.abs(Date.parse(sorted[0].validTime) - targetMs);
     if (bestDelta > VALID_TIME_THRESHOLD_MS) continue;
     anyWithinThreshold = true;
+    if (hazard === "IFR") ifrWithinThreshold = true;
 
     const bestTime = sorted[0].validTime;
     const atBestTime = list.filter((f) => f.validTime === bestTime);
@@ -108,6 +110,12 @@ export function classifyAirmets(
     if (hazard === "TURB") result.turb = hit;
     if (hazard === "MTN OBSC") result.mtnObsc = hit;
     if (hazard === "IFR") result.cielVis = hit;
+  }
+
+  if (ifrWithinThreshold) {
+    result.warnings.push(
+      "AIRMET IFR auto-flag uses 1000 ft / 3 sm threshold, not the worksheet's 2000 ft / 10 sm threshold"
+    );
   }
 
   if (!anyWithinThreshold) {

--- a/src/utils/gairmetApi.ts
+++ b/src/utils/gairmetApi.ts
@@ -1,0 +1,120 @@
+const BASE_URL = "/api/aviation-weather";
+
+export interface GAirmetCoord {
+  lat: string;
+  lon: string;
+}
+
+export interface GAirmetFeature {
+  hazard: "TURB" | "IFR" | "MTN OBSC" | "ICE" | "LLWS" | "SFC_WND" | string;
+  validTime: string;
+  forecastHour: number;
+  geom: "AREA" | string;
+  coords: GAirmetCoord[];
+}
+
+export interface AirmetClassification {
+  turb: boolean | null;
+  cielVis: boolean | null;
+  mtnObsc: boolean | null;
+  warnings: string[];
+}
+
+const VALID_TIME_THRESHOLD_MS = 3 * 60 * 60 * 1000;
+
+export async function fetchGAirmets(): Promise<GAirmetFeature[]> {
+  const url = `${BASE_URL}?endpoint=gairmet&format=json`;
+  const res = await fetch(url, {
+    method: "GET",
+    headers: { Accept: "application/json" },
+  });
+  if (!res.ok) {
+    throw new Error(`G-AIRMET fetch failed: ${res.status} ${res.statusText}`);
+  }
+  const json = await res.json();
+  return Array.isArray(json) ? (json as GAirmetFeature[]) : [];
+}
+
+export function pointInPolygon(
+  point: [number, number],
+  polygon: [number, number][]
+): boolean {
+  const [pLat, pLon] = point;
+  let inside = false;
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+    const [iLat, iLon] = polygon[i];
+    const [jLat, jLon] = polygon[j];
+    const intersect =
+      iLon > pLon !== jLon > pLon &&
+      pLat <= ((jLat - iLat) * (pLon - iLon)) / (jLon - iLon) + iLat;
+    if (intersect) inside = !inside;
+  }
+  return inside;
+}
+
+function airmetCoords(a: GAirmetFeature): [number, number][] {
+  return a.coords.map((c) => [Number(c.lat), Number(c.lon)]);
+}
+
+export function classifyAirmets(
+  features: GAirmetFeature[],
+  position: [number, number],
+  midTime: Date
+): AirmetClassification {
+  const warnings: string[] = [];
+  const targetMs = midTime.getTime();
+  const eligible = features.filter((f) =>
+    ["TURB", "IFR", "MTN OBSC"].includes(f.hazard)
+  );
+  if (eligible.length === 0) {
+    warnings.push(
+      `G-AIRMET data unavailable for ${midTime.toISOString()}; turb / cielVis / mtnObsc flags not updated`
+    );
+    return { turb: null, cielVis: null, mtnObsc: null, warnings };
+  }
+
+  // Group by hazard
+  const byHazard = new Map<string, GAirmetFeature[]>();
+  for (const f of eligible) {
+    const list = byHazard.get(f.hazard) ?? [];
+    list.push(f);
+    byHazard.set(f.hazard, list);
+  }
+
+  const result: AirmetClassification = {
+    turb: false,
+    cielVis: false,
+    mtnObsc: false,
+    warnings,
+  };
+
+  let anyWithinThreshold = false;
+  for (const [hazard, list] of byHazard.entries()) {
+    // Sort by abs delta from midTime; pick closest validTime
+    const sorted = [...list].sort(
+      (a, b) =>
+        Math.abs(Date.parse(a.validTime) - targetMs) -
+        Math.abs(Date.parse(b.validTime) - targetMs)
+    );
+    const bestDelta = Math.abs(Date.parse(sorted[0].validTime) - targetMs);
+    if (bestDelta > VALID_TIME_THRESHOLD_MS) continue;
+    anyWithinThreshold = true;
+
+    const bestTime = sorted[0].validTime;
+    const atBestTime = list.filter((f) => f.validTime === bestTime);
+    const hit = atBestTime.some((f) =>
+      pointInPolygon(position, airmetCoords(f))
+    );
+    if (hazard === "TURB") result.turb = hit;
+    if (hazard === "MTN OBSC") result.mtnObsc = hit;
+    if (hazard === "IFR") result.cielVis = hit;
+  }
+
+  if (!anyWithinThreshold) {
+    warnings.push(
+      `G-AIRMET data unavailable within 3 hr of ${midTime.toISOString()}; turb / cielVis / mtnObsc flags not updated`
+    );
+    return { turb: null, cielVis: null, mtnObsc: null, warnings };
+  }
+  return result;
+}

--- a/src/utils/weatherDataMapper.test.ts
+++ b/src/utils/weatherDataMapper.test.ts
@@ -374,7 +374,7 @@ describe("Weather Data Mapper", () => {
         flightTime: "12:00",
       };
 
-      const result = mapWeatherDataToWorksheet(mockApiData, null, options);
+      const result = mapWeatherDataToWorksheet(mockApiData, null, null, options);
 
       expect(result.success).toBe(true);
       expect(result.data.temp).toBeDefined();
@@ -386,7 +386,7 @@ describe("Weather Data Mapper", () => {
     it("should handle missing data gracefully", () => {
       const emptyApiData = {};
 
-      const result = mapWeatherDataToWorksheet(emptyApiData, null);
+      const result = mapWeatherDataToWorksheet(emptyApiData, null, null);
 
       expect(result.success).toBe(true);
       expect(result.warnings).toContain("No wind/temperature data available");
@@ -399,7 +399,7 @@ describe("Weather Data Mapper", () => {
     });
 
     it("should validate data when validation is enabled", () => {
-      const result = mapWeatherDataToWorksheet({}, null, {
+      const result = mapWeatherDataToWorksheet({}, null, null, {
         validateData: true,
       });
 
@@ -416,7 +416,7 @@ describe("Weather Data Mapper", () => {
         airport: 42 as unknown as [],
       };
 
-      const result = mapWeatherDataToWorksheet(malformedApiData, null);
+      const result = mapWeatherDataToWorksheet(malformedApiData, null, null);
 
       // Should handle gracefully
       expect(result.success).toBe(true);
@@ -467,6 +467,7 @@ describe("Weather Data Mapper", () => {
       const result = mapWeatherDataToWorksheet(
         apiDataWithMultipleAirports,
         null,
+        null,
         options
       );
 
@@ -494,7 +495,7 @@ describe("Weather Data Mapper", () => {
         warnings: ["test warning from areaOfOps"],
       };
 
-      const result = mapWeatherDataToWorksheet({}, mockAreaOfOps);
+      const result = mapWeatherDataToWorksheet({}, mockAreaOfOps, null);
 
       // Wind should be taken from areaOfOps
       expect(result.data.wind).toBeDefined();
@@ -751,6 +752,30 @@ describe("Weather Data Mapper", () => {
       expect(result.altimeter![0]).toBe(29.85); // API data should overwrite
       expect(result.rwy![0]).toBe(10000); // API data should overwrite
     });
+
+    it("overwrites turb/cielVis/mtnObsc to false when API explicitly says false", () => {
+      const existing = { turb: true, cielVis: true, mtnObsc: true };
+      const apiData = { turb: false, cielVis: false, mtnObsc: false };
+      const merged = mergeWeatherData(existing, apiData, true);
+      expect(merged.turb).toBe(false);
+      expect(merged.cielVis).toBe(false);
+      expect(merged.mtnObsc).toBe(false);
+    });
+
+    it("leaves turb/cielVis/mtnObsc untouched when API value is null", () => {
+      const existing = { turb: true, cielVis: false, mtnObsc: true };
+      const apiData = { turb: null, cielVis: null, mtnObsc: null } as Partial<
+        Record<"turb" | "cielVis" | "mtnObsc", boolean | null>
+      >;
+      const merged = mergeWeatherData(
+        existing,
+        apiData as Partial<typeof existing>,
+        true
+      );
+      expect(merged.turb).toBe(true);
+      expect(merged.cielVis).toBe(false);
+      expect(merged.mtnObsc).toBe(true);
+    });
   });
 
   describe("dep/arr time-aware weather", () => {
@@ -857,7 +882,7 @@ describe("Weather Data Mapper", () => {
 
   describe("Edge Cases", () => {
     it("should handle null and undefined values gracefully", () => {
-      const result = mapWeatherDataToWorksheet({}, null, {
+      const result = mapWeatherDataToWorksheet({}, null, null, {
         validateData: true,
       });
 
@@ -888,7 +913,7 @@ describe("Weather Data Mapper", () => {
         airport: [],
       };
 
-      const result = mapWeatherDataToWorksheet(emptyApiData, null);
+      const result = mapWeatherDataToWorksheet(emptyApiData, null, null);
 
       expect(result.success).toBe(true);
       expect(result.warnings.length).toBeGreaterThan(0);

--- a/src/utils/weatherDataMapper.test.ts
+++ b/src/utils/weatherDataMapper.test.ts
@@ -523,7 +523,7 @@ describe("Weather Data Mapper", () => {
         warnings: [],
       };
 
-      const result = mapWeatherDataToWorksheet({}, mockAreaOfOps, {
+      const result = mapWeatherDataToWorksheet({}, mockAreaOfOps, null, {
         validateData: true,
       });
 
@@ -550,7 +550,7 @@ describe("Weather Data Mapper", () => {
         opAltimeter: null,
         warnings: [],
       };
-      const result = mapWeatherDataToWorksheet({}, mockAreaOfOps, {
+      const result = mapWeatherDataToWorksheet({}, mockAreaOfOps, null, {
         validateData: true,
       });
       expect(

--- a/src/utils/weatherDataMapper.ts
+++ b/src/utils/weatherDataMapper.ts
@@ -578,16 +578,12 @@ export function mergeWeatherData(
     }
   }
 
-  // AIRMET boolean flags: null means fetch failed (leave alone), true/false both overwrite
-  if (apiData.turb !== undefined && apiData.turb !== null) {
-    result.turb = apiData.turb as boolean;
-  }
-  if (apiData.cielVis !== undefined && apiData.cielVis !== null) {
-    result.cielVis = apiData.cielVis as boolean;
-  }
-  if (apiData.mtnObsc !== undefined && apiData.mtnObsc !== null) {
-    result.mtnObsc = apiData.mtnObsc as boolean;
-  }
+  // AIRMET boolean flags: only overwrite when the API supplied an explicit
+  // boolean. Anything else (undefined / null sentinel for "data unavailable")
+  // leaves the existing value alone.
+  if (typeof apiData.turb === "boolean") result.turb = apiData.turb;
+  if (typeof apiData.cielVis === "boolean") result.cielVis = apiData.cielVis;
+  if (typeof apiData.mtnObsc === "boolean") result.mtnObsc = apiData.mtnObsc;
 
   return result;
 }

--- a/src/utils/weatherDataMapper.ts
+++ b/src/utils/weatherDataMapper.ts
@@ -223,6 +223,7 @@ export function mapWeatherDataToWorksheet(
     airport?: AirportResponse[];
   },
   areaOfOps: AreaOfOpsWeather | null,
+  airmets: import("./gairmetApi").AirmetClassification | null,
   options: WeatherMappingOptions = {}
 ): WeatherMappingResult {
   const result: WeatherMappingResult = {
@@ -299,6 +300,17 @@ export function mapWeatherDataToWorksheet(
         }
       }
       result.warnings.push(...areaOfOps.warnings);
+    }
+
+    // Apply G-AIRMET classification results
+    if (airmets) {
+      if (airmets.turb !== null)
+        (result.data as Partial<WorksheetData>).turb = airmets.turb;
+      if (airmets.cielVis !== null)
+        (result.data as Partial<WorksheetData>).cielVis = airmets.cielVis;
+      if (airmets.mtnObsc !== null)
+        (result.data as Partial<WorksheetData>).mtnObsc = airmets.mtnObsc;
+      result.warnings.push(...airmets.warnings);
     }
 
     // Validate mapped data
@@ -564,6 +576,17 @@ export function mergeWeatherData(
     } else {
       result.altitude = apiData.altitude;
     }
+  }
+
+  // AIRMET boolean flags: null means fetch failed (leave alone), true/false both overwrite
+  if (apiData.turb !== undefined && apiData.turb !== null) {
+    result.turb = apiData.turb as boolean;
+  }
+  if (apiData.cielVis !== undefined && apiData.cielVis !== null) {
+    result.cielVis = apiData.cielVis as boolean;
+  }
+  if (apiData.mtnObsc !== undefined && apiData.mtnObsc !== null) {
+    result.mtnObsc = apiData.mtnObsc as boolean;
   }
 
   return result;


### PR DESCRIPTION
## Summary
Stack 3 of 3 for [issue #56](https://github.com/jloosli/mountain-worksheet/issues/56). Stacked on top of PR 2; GitHub will auto-retarget this PR's base as the upstream PRs merge.

- New \`gairmetApi\`: \`fetchGAirmets\` + ray-casting \`pointInPolygon\` + \`classifyAirmets\`
- \`WeatherDataIntegration\` fetches G-AIRMETs in parallel with Open-Meteo at the operating position and midpoint time
- \`mergeWeatherData\` overwrites \`turb\` / \`cielVis\` / \`mtnObsc\` on each fetch (\`null\` sentinel preserves existing values when the AIRMET fetch failed)
- Surfaces the spec-mandated note that AIRMET IFR uses a 1000 ft / 3 sm threshold (narrower than the worksheet's 2000 ft / 10 sm \`cielVis\` label) so pilots aren't misled
- Emits a "skipped" warning when the operating position can't be resolved from either user input or airport coords
- Final-review fix commits: parallel \`Promise.allSettled\` between Open-Meteo and G-AIRMET fetches; partial-failure regression tests

Spec: [\`docs/superpowers/specs/2026-05-10-weather-data-improvements-design.md\`](docs/superpowers/specs/2026-05-10-weather-data-improvements-design.md) (Phase C)

## Stack
- → PR 1 (#92): time-aware dep/arr + warnings infrastructure
- → PR 2: Open-Meteo aloft + retire windtemp
- → **PR 3 (this one):** G-AIRMET auto-flag

After this stack lands, issue #56 closes.

## Test plan
- [ ] All existing tests pass; new \`gairmetApi\` suite green
- [ ] Manual: AIRMETs over op position toggle the checkboxes
- [ ] Manual: refetching when AIRMETs no longer cover the position unchecks the boxes
- [ ] Manual: G-AIRMET fetch failure (or Open-Meteo failure) does not break the rest of the pipeline
- [ ] Manual: blank position with no airport coords surfaces a "skipped" warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)