### PR TITLE
Add Instructions and Notes component (#96)

### DIFF
--- a/src/components/AppContainer.tsx
+++ b/src/components/AppContainer.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import AppInputs from "@/components/AppInputs";
 import Calculations from "@/components/Calculations";
+import InstructionsAndNotes from "@/components/InstructionsAndNotes";
 import MountainFlyingChecklist from "@/components/MountainFlyingChecklist";
 import WorksheetHeader from "@/components/WorksheetHeader";
 import { useUrlState } from "@/utils/useUrlState";
@@ -124,6 +125,7 @@ export default function AppContainer() {
       />
       <main className="flex-1 w-full flex justify-center px-2 md:px-8 pb-20">
         <div className="w-full max-w-5xl flex flex-col gap-16 items-center">
+          <InstructionsAndNotes />
           <AppInputs
             state={state}
             onStateUpdate={handleUpdate}

--- a/src/components/InstructionsAndNotes.test.tsx
+++ b/src/components/InstructionsAndNotes.test.tsx
@@ -54,4 +54,21 @@ describe("InstructionsAndNotes", () => {
     expect(screen.getByText(/All times are entered in UTC/i)).toBeInTheDocument();
     expect(screen.getByText(/Copy Link/i)).toBeInTheDocument();
   });
+
+  it("clarifies that the °C/°F preference is local and not part of the share link", () => {
+    render(<InstructionsAndNotes />);
+    expect(
+      screen.getByText(/UI preferences such as the °C\/°F unit are stored locally/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/the °C\/°F preference is preserved/i)
+    ).toBeInTheDocument();
+  });
+
+  it("marks the decorative chevron as aria-hidden", () => {
+    const { container } = render(<InstructionsAndNotes />);
+    const chevron = container.querySelector('span[aria-hidden="true"]');
+    expect(chevron).not.toBeNull();
+    expect(chevron).toHaveTextContent("▼");
+  });
 });

--- a/src/components/InstructionsAndNotes.test.tsx
+++ b/src/components/InstructionsAndNotes.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, within } from "../test-utils/test-utils";
+import InstructionsAndNotes from "./InstructionsAndNotes";
+
+describe("InstructionsAndNotes", () => {
+  it("renders a collapsible summary titled 'Instructions and Notes'", () => {
+    render(<InstructionsAndNotes />);
+    const summary = screen.getByText("Instructions and Notes");
+    expect(summary).toBeInTheDocument();
+    expect(summary.tagName).toBe("SUMMARY");
+  });
+
+  it("links to AviationWeather.gov", () => {
+    render(<InstructionsAndNotes />);
+    const link = screen.getByRole("link", { name: /aviationweather\.gov/i });
+    expect(link).toHaveAttribute("href", "https://aviationweather.gov/");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));
+  });
+
+  it("documents departure/arrival airports use 4-letter ICAO codes", () => {
+    render(<InstructionsAndNotes />);
+    expect(
+      screen.getByText(/Enter the 4-letter ICAO code/i)
+    ).toBeInTheDocument();
+  });
+
+  it("includes a table of supported Area-of-Operations formats with examples", () => {
+    render(<InstructionsAndNotes />);
+    const table = screen.getByRole("table");
+    expect(within(table).getByText("36.01N/75.50W")).toBeInTheDocument();
+    expect(within(table).getByText("360051N/0753004W")).toBeInTheDocument();
+    expect(within(table).getByText("3600.86N/07530.07W")).toBeInTheDocument();
+    expect(within(table).getByText("KOGD/285/34")).toBeInTheDocument();
+    expect(within(table).getByText("OGD/285/34")).toBeInTheDocument();
+  });
+
+  it("calls out the tool-is-for-reference disclaimer", () => {
+    render(<InstructionsAndNotes />);
+    expect(
+      screen.getByText(/This tool is for reference purposes only\./i)
+    ).toBeInTheDocument();
+  });
+
+  it("mentions key operational notes", () => {
+    render(<InstructionsAndNotes />);
+    expect(screen.getByText(/CAPF 70-5/i)).toBeInTheDocument();
+    expect(screen.getByText(/CAPF 70-91/i)).toBeInTheDocument();
+    expect(screen.getByText(/16,000' altitude limit/i)).toBeInTheDocument();
+    expect(screen.getByText(/dry air approximation/i)).toBeInTheDocument();
+  });
+
+  it("explains UTC time handling and link sharing for the tool", () => {
+    render(<InstructionsAndNotes />);
+    expect(screen.getByText(/All times are entered in UTC/i)).toBeInTheDocument();
+    expect(screen.getByText(/Copy Link/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/InstructionsAndNotes.tsx
+++ b/src/components/InstructionsAndNotes.tsx
@@ -1,0 +1,203 @@
+const positionFormats: Array<{
+  format: string;
+  example: string;
+  entry: string;
+  decimal: string;
+}> = [
+  {
+    format: "DD.dd (with letters)",
+    example: "36.01°N / 75.50°W",
+    entry: "36.01N/75.50W",
+    decimal: "36.01/-75.50",
+  },
+  {
+    format: "DD.dd (with a minus)",
+    example: "36.01°N / 75.50°W",
+    entry: "36.01/-75.50",
+    decimal: "36.01/-75.50",
+  },
+  {
+    format: "DD°MM'SS\" (with letters)",
+    example: "36°00'51\"N / 75°30'04\"W",
+    entry: "360051N/0753004W",
+    decimal: "36.01/-75.50",
+  },
+  {
+    format: "DD°MM'SS\" (with a minus)",
+    example: "36°00'51\"N / 75°30'04\"W",
+    entry: "360051/-0753004",
+    decimal: "36.01/-75.50",
+  },
+  {
+    format: "DD°MM.mm (with letters)",
+    example: "36°00.86'N / 75°30.07'W",
+    entry: "3600.86N/07530.07W",
+    decimal: "36.01/-75.50",
+  },
+  {
+    format: "DD°MM.mm (with a minus)",
+    example: "36°00.86'N / 75°30.07'W",
+    entry: "3600.86/-07530.07",
+    decimal: "36.01/-75.50",
+  },
+  {
+    format: "Airport ID / Radial / Distance",
+    example: "41.43 / -112.70",
+    entry: "KOGD/285/34",
+    decimal: "41.43/-112.70",
+  },
+  {
+    format: "VOR ID / Radial / Distance",
+    example: "41.50 / -112.76",
+    entry: "OGD/285/34",
+    decimal: "41.50/-112.76",
+  },
+];
+
+const usingTheToolNotes: string[] = [
+  "All times are entered in UTC. The local-time conversion shows below the time selector.",
+  "Sortie date and time drive the weather lookup — departure and arrival METAR/TAF are matched to your sortie time, not the current time.",
+  "Use Copy Link to save or share the worksheet — the URL captures every field, so the recipient (e.g., your FRO) sees the same values.",
+  "Reset Worksheet clears every input. Copy the link first if you want to keep the current state.",
+  "Toggle °C/°F at any time using the temperature unit button in the header. All temperature inputs and outputs update together.",
+  "Operating Altitude drives the in-flight density-altitude and maneuvering-speed calculations. Set it to the planned altitude you'll be operating at over the area.",
+  "Review the Mountain Flying Checklist (at the bottom of the page) before flight in addition to the worksheet values.",
+];
+
+const operationalNotes: string[] = [
+  "This tool is for reference purposes only. It is up to the PIC and FRO to responsibly evaluate risks prior to release or departure. If risks cannot be reduced to an acceptable level, a no-go decision should be considered.",
+  "Warnings are highlighted in red/yellow, but the worksheet does not cover all the risks involved.",
+  "Complete and upload this document to 'Sortie Files' for a mountain flight.",
+  "If computations reveal that a particular performance item is marginal, consult the POH prior to flight.",
+  "C206: 16,000' altitude limit is based on aircraft operations below critical altitude. See POH for operations above this altitude.",
+  "Some performance values may vary slightly from the POH for temperatures, altitudes, and weights.",
+  "Rate of Climb (ROC) for actual weights is an estimate only. ROC at Max Gross Weights (MGW) are from the POH. Therefore, actual ROC and MGW ROC values may not match. If actual weight results are unexpected, use MGW or POH values. Remember, POH values are for a new aircraft with a test pilot. Your actual climb rates can, and probably will be, lower. ROC rates that are significantly lower than POH values may justify a Return to Base decision.",
+  "Performance is computed from POH tables but may not be accurate outside the table range.",
+  "A current CAPF 70-5 Mountain Flight Endorsement or qualified instructor is required to takeoff/land in airports located in mountainous terrain.",
+  "A current Mountain Flying Certification SQTR and CAPF 70-91, Section V signoff, or qualified instructor is required to fly mountain search.",
+  "Density altitude calculation uses a dry air approximation.",
+];
+
+export default function InstructionsAndNotes() {
+  return (
+    <div className="w-full max-w-4xl bg-white dark:bg-gray-800 rounded-lg shadow-md">
+      <details>
+        <summary className="text-2xl font-bold p-6 cursor-pointer list-none flex items-center justify-between select-none">
+          Instructions and Notes
+          <span className="text-gray-400 dark:text-gray-500 text-base font-normal ml-2">
+            ▼
+          </span>
+        </summary>
+        <div className="px-6 pb-6 space-y-6 text-sm text-gray-700 dark:text-gray-300">
+          <p>
+            Add sortie information to the input section. Once that area is
+            filled in, click the{" "}
+            <span className="font-semibold">Fetch Weather</span> button and the
+            worksheet will fetch weather information from{" "}
+            <a
+              href="https://aviationweather.gov/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 dark:text-blue-400 hover:underline"
+            >
+              AviationWeather.gov
+            </a>{" "}
+            to fill out the weather and performance sections of the worksheet.
+          </p>
+
+          <section className="space-y-2">
+            <h3 className="text-base font-semibold text-gray-800 dark:text-gray-200">
+              Special Inputs
+            </h3>
+            <p>
+              <span className="font-semibold">
+                Departure / Arrival airports:
+              </span>{" "}
+              Enter the 4-letter ICAO code (e.g. KDEN) and the worksheet will
+              populate the weather and runway information when clicking{" "}
+              <span className="font-semibold">Fetch Weather</span>.
+            </p>
+            <p>
+              <span className="font-semibold">Area of Operations:</span> Enter
+              latitude/longitude coordinates in decimal degrees DD.dddd format.
+              You can also use other ways to indicate the area of operations —
+              see the table below.
+            </p>
+
+            <div className="overflow-x-auto">
+              <table className="min-w-full text-xs border-collapse mt-2">
+                <thead>
+                  <tr className="bg-gray-100 dark:bg-gray-700 text-left">
+                    <th className="border border-gray-300 dark:border-gray-600 px-2 py-1 font-semibold">
+                      Format
+                    </th>
+                    <th className="border border-gray-300 dark:border-gray-600 px-2 py-1 font-semibold">
+                      Equivalent Lat/Long
+                    </th>
+                    <th className="border border-gray-300 dark:border-gray-600 px-2 py-1 font-semibold">
+                      How It Is Entered
+                    </th>
+                    <th className="border border-gray-300 dark:border-gray-600 px-2 py-1 font-semibold">
+                      Converted Decimal Format
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {positionFormats.map((row) => (
+                    <tr key={row.entry}>
+                      <td className="border border-gray-300 dark:border-gray-600 px-2 py-1">
+                        {row.format}
+                      </td>
+                      <td className="border border-gray-300 dark:border-gray-600 px-2 py-1 whitespace-nowrap">
+                        {row.example}
+                      </td>
+                      <td className="border border-gray-300 dark:border-gray-600 px-2 py-1 font-mono whitespace-nowrap">
+                        {row.entry}
+                      </td>
+                      <td className="border border-gray-300 dark:border-gray-600 px-2 py-1 font-mono whitespace-nowrap">
+                        {row.decimal}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section className="space-y-2">
+            <h3 className="text-base font-semibold text-gray-800 dark:text-gray-200">
+              Using the Tool
+            </h3>
+            <ul className="list-disc list-outside ml-5 space-y-1">
+              {usingTheToolNotes.map((note) => (
+                <li key={note}>{note}</li>
+              ))}
+            </ul>
+          </section>
+
+          <section className="space-y-2">
+            <h3 className="text-base font-semibold text-gray-800 dark:text-gray-200">
+              Notes
+            </h3>
+            <ul className="list-disc list-outside ml-5 space-y-1">
+              {operationalNotes.map((note) => (
+                <li key={note}>
+                  {note.startsWith("This tool is for reference") ? (
+                    <>
+                      <span className="font-semibold">
+                        This tool is for reference purposes only.
+                      </span>{" "}
+                      {note.replace("This tool is for reference purposes only. ", "")}
+                    </>
+                  ) : (
+                    note
+                  )}
+                </li>
+              ))}
+            </ul>
+          </section>
+        </div>
+      </details>
+    </div>
+  );
+}

--- a/src/components/InstructionsAndNotes.tsx
+++ b/src/components/InstructionsAndNotes.tsx
@@ -57,15 +57,20 @@ const positionFormats: Array<{
 const usingTheToolNotes: string[] = [
   "All times are entered in UTC. The local-time conversion shows below the time selector.",
   "Sortie date and time drive the weather lookup — departure and arrival METAR/TAF are matched to your sortie time, not the current time.",
-  "Use Copy Link to save or share the worksheet — the URL captures every field, so the recipient (e.g., your FRO) sees the same values.",
-  "Reset Worksheet clears every input. Copy the link first if you want to keep the current state.",
-  "Toggle °C/°F at any time using the temperature unit button in the header. All temperature inputs and outputs update together.",
+  "Use Copy Link to save or share the worksheet — the URL captures the worksheet inputs and fetched weather/performance values. UI preferences such as the °C/°F unit are stored locally in your browser and are not shared via the link.",
+  "Reset Worksheet clears the worksheet inputs from the URL and reloads with defaults — the date and time reset to the next top-of-hour in UTC, and the °C/°F preference is preserved. Copy the link first if you want to keep the current state.",
+  "Toggle °C/°F at any time using the temperature unit button in the header. The setting is saved locally in your browser so it persists across sessions on the same device.",
   "Operating Altitude drives the in-flight density-altitude and maneuvering-speed calculations. Set it to the planned altitude you'll be operating at over the area.",
   "Review the Mountain Flying Checklist (at the bottom of the page) before flight in addition to the worksheet values.",
 ];
 
-const operationalNotes: string[] = [
-  "This tool is for reference purposes only. It is up to the PIC and FRO to responsibly evaluate risks prior to release or departure. If risks cannot be reduced to an acceptable level, a no-go decision should be considered.",
+type OperationalNote = string | { emphasis: string; body: string };
+
+const operationalNotes: OperationalNote[] = [
+  {
+    emphasis: "This tool is for reference purposes only.",
+    body: " It is up to the PIC and FRO to responsibly evaluate risks prior to release or departure. If risks cannot be reduced to an acceptable level, a no-go decision should be considered.",
+  },
   "Warnings are highlighted in red/yellow, but the worksheet does not cover all the risks involved.",
   "Complete and upload this document to 'Sortie Files' for a mountain flight.",
   "If computations reveal that a particular performance item is marginal, consult the POH prior to flight.",
@@ -84,7 +89,10 @@ export default function InstructionsAndNotes() {
       <details>
         <summary className="text-2xl font-bold p-6 cursor-pointer list-none flex items-center justify-between select-none">
           Instructions and Notes
-          <span className="text-gray-400 dark:text-gray-500 text-base font-normal ml-2">
+          <span
+            aria-hidden="true"
+            className="text-gray-400 dark:text-gray-500 text-base font-normal ml-2"
+          >
             ▼
           </span>
         </summary>
@@ -180,20 +188,17 @@ export default function InstructionsAndNotes() {
               Notes
             </h3>
             <ul className="list-disc list-outside ml-5 space-y-1">
-              {operationalNotes.map((note) => (
-                <li key={note}>
-                  {note.startsWith("This tool is for reference") ? (
-                    <>
-                      <span className="font-semibold">
-                        This tool is for reference purposes only.
-                      </span>{" "}
-                      {note.replace("This tool is for reference purposes only. ", "")}
-                    </>
-                  ) : (
-                    note
-                  )}
-                </li>
-              ))}
+              {operationalNotes.map((note) => {
+                if (typeof note === "string") {
+                  return <li key={note}>{note}</li>;
+                }
+                return (
+                  <li key={note.emphasis}>
+                    <span className="font-semibold">{note.emphasis}</span>
+                    {note.body}
+                  </li>
+                );
+              })}
             </ul>
           </section>
         </div>

--- a/src/components/InstructionsAndNotes.tsx
+++ b/src/components/InstructionsAndNotes.tsx
@@ -42,13 +42,13 @@ const positionFormats: Array<{
   },
   {
     format: "Airport ID / Radial / Distance",
-    example: "41.43 / -112.70",
+    example: "41°25'48\"N / 112°42'00\"W",
     entry: "KOGD/285/34",
     decimal: "41.43/-112.70",
   },
   {
     format: "VOR ID / Radial / Distance",
-    example: "41.50 / -112.76",
+    example: "41°30'00\"N / 112°45'36\"W",
     entry: "OGD/285/34",
     decimal: "41.50/-112.76",
   },
@@ -140,10 +140,10 @@ export default function InstructionsAndNotes() {
                       Format
                     </th>
                     <th className="border border-gray-300 dark:border-gray-600 px-2 py-1 font-semibold">
-                      Equivalent Lat/Long
+                      How It Is Entered
                     </th>
                     <th className="border border-gray-300 dark:border-gray-600 px-2 py-1 font-semibold">
-                      How It Is Entered
+                      Equivalent Lat/Long
                     </th>
                     <th className="border border-gray-300 dark:border-gray-600 px-2 py-1 font-semibold">
                       Converted Decimal Format
@@ -156,11 +156,11 @@ export default function InstructionsAndNotes() {
                       <td className="border border-gray-300 dark:border-gray-600 px-2 py-1">
                         {row.format}
                       </td>
-                      <td className="border border-gray-300 dark:border-gray-600 px-2 py-1 whitespace-nowrap">
-                        {row.example}
-                      </td>
                       <td className="border border-gray-300 dark:border-gray-600 px-2 py-1 font-mono whitespace-nowrap">
                         {row.entry}
+                      </td>
+                      <td className="border border-gray-300 dark:border-gray-600 px-2 py-1 whitespace-nowrap">
+                        {row.example}
                       </td>
                       <td className="border border-gray-300 dark:border-gray-600 px-2 py-1 font-mono whitespace-nowrap">
                         {row.decimal}

--- a/src/components/InstructionsAndNotes.tsx
+++ b/src/components/InstructionsAndNotes.tsx
@@ -6,13 +6,13 @@ const positionFormats: Array<{
 }> = [
   {
     format: "DD.dd (with letters)",
-    example: "36.01°N / 75.50°W",
+    example: "36°00'36\"N / 75°30'00\"W",
     entry: "36.01N/75.50W",
     decimal: "36.01/-75.50",
   },
   {
     format: "DD.dd (with a minus)",
-    example: "36.01°N / 75.50°W",
+    example: "36°00'36\"N / 75°30'00\"W",
     entry: "36.01/-75.50",
     decimal: "36.01/-75.50",
   },


### PR DESCRIPTION
Closes #96.

## Summary
- New collapsible **Instructions and Notes** panel mirroring `MountainFlyingChecklist` (same `<details>`/`<summary>` pattern, dark-mode styling).
- Wired into `AppContainer` directly above `AppInputs`.
- Contents:
  - Intro paragraph + link to **AviationWeather.gov** explaining the Fetch Weather flow.
  - **Special Inputs** — ICAO airport guidance + full Area-of-Operations format table (all 8 supported formats: DD.dd, DMS, DMM, airport-RD, VOR-RD; both letter and minus-sign variants).
  - **Using the Tool** — additional notes derived from the codebase that weren't in the issue: UTC time entry (with local-time conversion), sortie-time-driven weather lookup, Copy Link, Reset, °C/°F toggle, Operating Altitude semantics, and reference to the Mountain Flying Checklist.
  - **Notes** — every operational disclaimer from the issue (PIC/FRO responsibility, CAPF 70-5 / 70-91 requirements, C206 16k ceiling caveat, POH/ROC disclaimers, dry-air density-altitude approximation, etc.).

## Test plan
- [x] `npm test` — 415 / 415 pass (7 new tests in `InstructionsAndNotes.test.tsx`)
- [x] `npm run lint` — clean
- [x] `npm run build` — production build succeeds
- [x] Manual browser check at `localhost:3000` — panel renders above inputs, collapses/expands correctly, dark mode looks right, table is horizontally scrollable on narrow widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)