### PR TITLE
Worksheet UI Redesign Phase 1: Step Shell Foundation

### DIFF
--- a/docs/decision-panel-mockup.html
+++ b/docs/decision-panel-mockup.html
@@ -1,0 +1,613 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Mountain Worksheet — Decision Panel (mockup v2)</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,300;9..144,400;9..144,600;9..144,800&family=B612:wght@400;700&family=B612+Mono:wght@400;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --paper:        #f7f5ef;     /* warm sectional-chart paper */
+      --paper-deep:   #efeae0;
+      --ink:          #1b1f24;
+      --ink-soft:     #4a5560;
+      --rule:         #d9d3c5;
+      --rule-soft:    #e8e3d6;
+      --emerald:      #0f7a4a;
+      --emerald-soft: #e1f1e7;
+      --amber:        #b8740b;
+      --amber-soft:   #fbeed1;
+      --crimson:      #a32626;
+      --crimson-soft: #f6dede;
+      --slate:        #1f2937;
+      --indigo-cold:  #2a3a52;
+    }
+
+    html { scroll-behavior: smooth; }
+    body {
+      font-family: 'B612', ui-sans-serif, system-ui, sans-serif;
+      color: var(--ink);
+      background: var(--paper);
+      /* Faint topographic contour pattern — like a sectional chart */
+      background-image:
+        radial-gradient(1200px 600px at 80% -200px, rgba(42, 58, 82, 0.05), transparent 60%),
+        repeating-linear-gradient(115deg, transparent 0 18px, rgba(120, 100, 60, 0.035) 18px 19px),
+        repeating-linear-gradient(25deg,  transparent 0 22px, rgba(120, 100, 60, 0.025) 22px 23px);
+    }
+
+    .font-display { font-family: 'Fraunces', ui-serif, Georgia, serif; font-optical-sizing: auto; }
+    .font-mono    { font-family: 'B612 Mono', ui-monospace, "SF Mono", Menlo, monospace; font-variant-numeric: tabular-nums; }
+    .num          { font-family: 'B612 Mono', ui-monospace, "SF Mono", Menlo, monospace; font-variant-numeric: tabular-nums; letter-spacing: -0.01em; }
+
+    /* Tiny tracking helper for ALL-CAPS labels */
+    .eyebrow { letter-spacing: 0.16em; text-transform: uppercase; font-size: 11px; font-weight: 700; }
+
+    /* Smooth scroll past sticky nav */
+    section[id^="step-"] { scroll-margin-top: 84px; }
+
+    /* Instrument-bezel ring for the numbered step circle */
+    .bezel {
+      background:
+        radial-gradient(circle at 30% 30%, rgba(255,255,255,0.18), transparent 55%),
+        var(--ink);
+      box-shadow:
+        0 0 0 1px rgba(0,0,0,0.10),
+        0 0 0 4px var(--paper),
+        0 0 0 5px var(--rule),
+        0 6px 14px -8px rgba(0,0,0,0.45);
+    }
+    .bezel.is-good    { background: radial-gradient(circle at 30% 30%, rgba(255,255,255,0.25), transparent 55%), var(--emerald); }
+    .bezel.is-warn    { background: radial-gradient(circle at 30% 30%, rgba(255,255,255,0.28), transparent 55%), var(--amber); }
+    .bezel.is-stop    { background: radial-gradient(circle at 30% 30%, rgba(255,255,255,0.28), transparent 55%), var(--crimson); }
+
+    /* The verdict slab — big serif on a tinted plate */
+    .verdict {
+      background:
+        linear-gradient(180deg, rgba(255,255,255,0.55) 0%, rgba(255,255,255,0) 60%),
+        var(--amber-soft);
+      border: 1px solid var(--rule);
+      border-left: 6px solid var(--amber);
+    }
+    .verdict-text {
+      font-family: 'Fraunces', serif;
+      font-variation-settings: "opsz" 144, "SOFT" 30;
+      font-weight: 400;
+      letter-spacing: -0.045em;
+      line-height: 0.92;
+    }
+
+    /* Instrument readout row */
+    .readout-row {
+      display: grid;
+      grid-template-columns: 6px 168px 1fr auto;
+      gap: 0;
+      align-items: stretch;
+      border: 1px solid var(--rule);
+      border-radius: 6px;
+      background: #fffdf7;
+      transition: transform 120ms ease, border-color 120ms ease, box-shadow 120ms ease;
+    }
+    .readout-row:hover {
+      border-color: #b8a87b;
+      box-shadow: 0 6px 18px -12px rgba(0,0,0,0.25);
+      transform: translateY(-1px);
+    }
+    .readout-band { border-radius: 5px 0 0 5px; }
+    .readout-band.ok   { background: var(--emerald); }
+    .readout-band.warn { background: var(--amber);   }
+    .readout-band.stop { background: var(--crimson); }
+
+    .readout-label {
+      padding: 14px 16px 12px;
+      border-right: 1px dashed var(--rule);
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      background: rgba(255,253,247,0.5);
+    }
+    .readout-value {
+      padding: 14px 18px 12px;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+    }
+    .readout-status {
+      padding: 14px 16px 12px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      border-left: 1px dashed var(--rule);
+      min-width: 110px;
+    }
+
+    /* Compass-rose accent at the top right of the verdict slab */
+    .rose {
+      position: absolute;
+      top: 18px; right: 18px;
+      width: 56px; height: 56px;
+      opacity: 0.32;
+      pointer-events: none;
+    }
+
+    /* Step shell card */
+    .card {
+      background: #fffdf7;
+      border: 1px solid var(--rule);
+      box-shadow: 0 1px 0 var(--paper-deep), 0 18px 40px -32px rgba(20, 25, 35, 0.25);
+    }
+
+    /* Sticky stepper */
+    .stepper-pill {
+      transition: background 120ms ease, color 120ms ease, box-shadow 120ms ease;
+      border: 1px solid var(--rule);
+      background: #fffdf7;
+    }
+    .stepper-pill.is-active {
+      background: var(--ink);
+      color: #fffdf7;
+      border-color: var(--ink);
+      box-shadow: 0 2px 0 var(--paper-deep);
+    }
+    .stepper-pill.is-active .stepper-num { background: #fffdf7; color: var(--ink); }
+    .stepper-pill.is-active .stepper-state { color: rgba(255,253,247,0.7); }
+
+    .stepper-num {
+      width: 22px; height: 22px; border-radius: 999px;
+      display: inline-flex; align-items: center; justify-content: center;
+      font-family: 'B612 Mono', monospace; font-weight: 700; font-size: 11px;
+    }
+
+    /* Header band */
+    .header-band {
+      background:
+        radial-gradient(800px 200px at 100% 0%, rgba(212, 184, 110, 0.22), transparent 60%),
+        linear-gradient(180deg, #14181f 0%, #1b2230 100%);
+    }
+
+    /* Hairline divider w/ text label, like a chart annotation */
+    .hr-label {
+      display: flex; align-items: center; gap: 12px;
+      color: var(--ink-soft);
+    }
+    .hr-label::before, .hr-label::after { content: ""; flex: 1; height: 1px; background: var(--rule); }
+
+    /* Subtle blink for the live time */
+    @keyframes pulse-dim { 0%, 100% { opacity: 1; } 50% { opacity: 0.55; } }
+    .pulse { animation: pulse-dim 1.8s ease-in-out infinite; }
+
+    /* Footer chart-margin tick marks */
+    .ticks {
+      background-image: repeating-linear-gradient(90deg, var(--rule) 0 1px, transparent 1px 12px);
+      height: 8px;
+    }
+
+    /* Make form controls feel paper-grade */
+    input[type="text"], input[type="number"], input[type="date"], select {
+      background: #fffdf7;
+      border: 1px solid var(--rule);
+      color: var(--ink);
+    }
+    input.fetched {
+      background: #eef4fb;
+      border-color: #95b4d4;
+      color: var(--indigo-cold);
+    }
+  </style>
+</head>
+<body class="min-h-screen">
+
+  <!-- ── Header ───────────────────────────────────────────────────────────── -->
+  <header class="header-band text-white">
+    <div class="mx-auto max-w-5xl px-5 md:px-7 py-5">
+      <div class="flex items-end justify-between gap-4 flex-wrap">
+        <div class="flex items-baseline gap-3">
+          <span class="eyebrow text-amber-300/90">CAP · Civil Air Patrol</span>
+          <span class="hidden md:inline text-white/30">·</span>
+          <span class="hidden md:inline eyebrow text-white/55">Pre-flight</span>
+        </div>
+        <div class="flex items-baseline gap-2 text-white/80">
+          <span class="num text-base">14:32:08</span>
+          <span class="eyebrow text-white/55">UTC</span>
+          <span class="text-white/30">·</span>
+          <span class="text-sm">Sun 10 May 2026</span>
+          <span class="pulse h-1.5 w-1.5 rounded-full bg-emerald-400 ml-1"></span>
+        </div>
+      </div>
+      <h1 class="font-display mt-2 text-4xl md:text-5xl font-normal tracking-tight" style="font-variation-settings: 'opsz' 144, 'SOFT' 50;">
+        Mountain Flying Worksheet
+      </h1>
+      <p class="mt-1 text-white/65 text-sm max-w-xl">A guided pre-flight check for mountain sorties — flight details, weather aloft, aircraft performance, and a go / no-go decision.</p>
+      <div class="mt-5 flex flex-wrap items-center gap-2">
+        <button class="rounded-md px-3 py-1.5 text-xs eyebrow text-white/70 hover:text-white hover:bg-white/5 border border-white/15">Reset</button>
+        <button class="rounded-md px-3 py-1.5 text-xs eyebrow text-white/70 hover:text-white hover:bg-white/5 border border-white/15 flex items-center gap-1.5">
+          <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M13.83 10.17a4 4 0 015.66 5.66l-3 3a4 4 0 01-5.66-5.66m-2 2a4 4 0 01-5.66-5.66l3-3a4 4 0 015.66 5.66"/></svg>
+          Copy link
+        </button>
+        <button class="rounded-md px-3 py-1.5 text-xs eyebrow text-white/70 hover:text-white hover:bg-white/5 border border-white/15 num">°F</button>
+        <span class="flex-1"></span>
+        <button class="group rounded-md px-4 py-2 text-sm font-semibold bg-amber-300 hover:bg-amber-200 text-slate-900 flex items-center gap-2 shadow-[0_4px_0_-0.5px_rgba(0,0,0,0.18)]">
+          <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2.25" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M3 15a4 4 0 004 4h10a5 5 0 100-10 7 7 0 00-13.5 2A4 4 0 003 15z"/></svg>
+          Fetch weather
+          <span class="eyebrow text-slate-900/55 ml-1 group-hover:text-slate-900/70">14:31</span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <!-- ── Sticky stepper ───────────────────────────────────────────────────── -->
+  <nav id="stepper" class="sticky top-0 z-20" style="background: rgba(247,245,239,0.86); backdrop-filter: blur(8px); border-bottom: 1px solid var(--rule);">
+    <div class="mx-auto max-w-5xl px-5 md:px-7 py-3">
+      <ol class="flex items-center gap-2 overflow-x-auto text-sm">
+        <li>
+          <a href="#step-1" data-step="step-1" class="step-link stepper-pill flex items-center gap-2 rounded-full px-3 py-1.5">
+            <span class="stepper-num" style="background: var(--ink); color: #fffdf7;">1</span>
+            <span>Flight details</span>
+            <span class="stepper-state eyebrow text-amber-700">8 / 11</span>
+          </a>
+        </li>
+        <li aria-hidden="true" class="num text-stone-400">→</li>
+        <li>
+          <a href="#step-2" data-step="step-2" class="step-link stepper-pill flex items-center gap-2 rounded-full px-3 py-1.5">
+            <span class="stepper-num" style="background: var(--emerald); color: #fffdf7;">2</span>
+            <span>Weather</span>
+            <span class="stepper-state eyebrow text-emerald-700">●</span>
+          </a>
+        </li>
+        <li aria-hidden="true" class="num text-stone-400">→</li>
+        <li>
+          <a href="#step-3" data-step="step-3" class="step-link stepper-pill flex items-center gap-2 rounded-full px-3 py-1.5">
+            <span class="stepper-num" style="background: var(--emerald); color: #fffdf7;">3</span>
+            <span>Performance</span>
+            <span class="stepper-state eyebrow text-emerald-700">●</span>
+          </a>
+        </li>
+        <li aria-hidden="true" class="num text-stone-400">→</li>
+        <li>
+          <a href="#step-4" data-step="step-4" class="step-link stepper-pill is-active flex items-center gap-2 rounded-full px-3 py-1.5">
+            <span class="stepper-num">4</span>
+            <span>Decision</span>
+            <span class="stepper-state eyebrow text-amber-700">REVIEW</span>
+          </a>
+        </li>
+      </ol>
+    </div>
+  </nav>
+
+  <!-- ── Main ─────────────────────────────────────────────────────────────── -->
+  <main class="mx-auto max-w-5xl px-5 md:px-7 py-10 space-y-7">
+
+    <!-- STEP 1 (collapsed glance) ─────────────────────────────────────────── -->
+    <section id="step-1" class="relative pl-14 md:pl-20">
+      <div class="absolute left-0 top-3 flex flex-col items-center" aria-hidden="true">
+        <div class="bezel h-10 w-10 rounded-full flex items-center justify-center font-mono font-bold text-white">1</div>
+        <div class="mt-2 w-px flex-1 bg-stone-300/80" style="min-height: 56px;"></div>
+      </div>
+      <article class="card rounded-lg overflow-hidden">
+        <header class="flex items-start justify-between gap-4 px-5 py-4 border-b border-stone-300/60">
+          <div>
+            <div class="eyebrow text-stone-500">Step 1</div>
+            <h2 class="font-display text-2xl tracking-tight" style="font-variation-settings: 'opsz' 60;">Flight Details</h2>
+          </div>
+          <span class="shrink-0 inline-flex items-center gap-1.5 rounded-full bg-amber-100/80 text-amber-800 border border-amber-300/70 px-2.5 py-1 text-xs font-semibold">
+            <span class="h-1.5 w-1.5 rounded-full bg-amber-500"></span>
+            8 of 11 fields
+          </span>
+        </header>
+        <div class="px-5 py-4 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-sm">
+          <div><div class="eyebrow text-stone-500">Pilot</div><div class="mt-0.5">J. Loosli</div></div>
+          <div><div class="eyebrow text-stone-500">Aircraft</div><div class="mt-0.5 num">C172S · N12345</div></div>
+          <div><div class="eyebrow text-stone-500">Departs</div><div class="mt-0.5 num">KOGD · 18:00z</div></div>
+          <div><div class="eyebrow text-stone-500">Arrives</div><div class="mt-0.5 num">KLGU · 20:00z</div></div>
+          <div><div class="eyebrow text-stone-500">Area of ops</div><div class="mt-0.5 num">KOGD / 285 / 34</div></div>
+          <div><div class="eyebrow text-stone-500">Op altitude</div><div class="mt-0.5 num">11,500 ft MSL</div></div>
+          <div><div class="eyebrow text-stone-500">T/O weight</div><div class="mt-0.5 num">2,400 lb</div></div>
+          <div><div class="eyebrow text-stone-500">Quals</div><div class="mt-0.5">70-5 ✓ · 70-91 ✓</div></div>
+        </div>
+      </article>
+    </section>
+
+    <!-- STEP 2 (glance) ───────────────────────────────────────────────────── -->
+    <section id="step-2" class="relative pl-14 md:pl-20">
+      <div class="absolute left-0 top-3 flex flex-col items-center" aria-hidden="true">
+        <div class="bezel is-good h-10 w-10 rounded-full flex items-center justify-center font-mono font-bold text-white">2</div>
+        <div class="mt-2 w-px flex-1 bg-stone-300/80" style="min-height: 56px;"></div>
+      </div>
+      <article class="card rounded-lg overflow-hidden">
+        <header class="flex items-start justify-between gap-4 px-5 py-4 border-b border-stone-300/60">
+          <div>
+            <div class="eyebrow text-stone-500">Step 2</div>
+            <h2 class="font-display text-2xl tracking-tight" style="font-variation-settings: 'opsz' 60;">Weather</h2>
+          </div>
+          <span class="shrink-0 inline-flex items-center gap-1.5 rounded-full bg-emerald-50 text-emerald-800 border border-emerald-200 px-2.5 py-1 text-xs font-semibold">
+            <span class="h-1.5 w-1.5 rounded-full" style="background: var(--emerald);"></span>
+            Fetched 14:31z
+          </span>
+        </header>
+        <div class="px-5 py-4 text-sm grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3">
+          <div><div class="eyebrow text-stone-500">Winds @ 9k</div><div class="num mt-0.5">300° · 25 kt</div></div>
+          <div><div class="eyebrow text-stone-500">Winds @ 12k</div><div class="num mt-0.5">310° · 32 kt</div></div>
+          <div><div class="eyebrow text-stone-500">FZL / Tropopause</div><div class="num mt-0.5">9,200 ft</div></div>
+          <div><div class="eyebrow text-stone-500">Advisories</div><div class="num mt-0.5 text-amber-800">Tango · Sierra</div></div>
+        </div>
+      </article>
+    </section>
+
+    <!-- STEP 3 (glance) ───────────────────────────────────────────────────── -->
+    <section id="step-3" class="relative pl-14 md:pl-20">
+      <div class="absolute left-0 top-3 flex flex-col items-center" aria-hidden="true">
+        <div class="bezel is-good h-10 w-10 rounded-full flex items-center justify-center font-mono font-bold text-white">3</div>
+        <div class="mt-2 w-px flex-1 bg-stone-300/80" style="min-height: 56px;"></div>
+      </div>
+      <article class="card rounded-lg overflow-hidden">
+        <header class="flex items-start justify-between gap-4 px-5 py-4 border-b border-stone-300/60">
+          <div>
+            <div class="eyebrow text-stone-500">Step 3</div>
+            <h2 class="font-display text-2xl tracking-tight" style="font-variation-settings: 'opsz' 60;">Aircraft Performance</h2>
+          </div>
+          <span class="shrink-0 inline-flex items-center gap-1.5 rounded-full bg-emerald-50 text-emerald-800 border border-emerald-200 px-2.5 py-1 text-xs font-semibold">
+            <span class="h-1.5 w-1.5 rounded-full" style="background: var(--emerald);"></span>
+            Auto-filled
+          </span>
+        </header>
+        <div class="px-5 py-4 text-sm grid grid-cols-3 gap-x-6 gap-y-3">
+          <div><div class="eyebrow text-stone-500">KOGD · departure</div><div class="num mt-0.5">68 °F · 30.12 · 4,473 ft</div></div>
+          <div><div class="eyebrow text-stone-500">Operating</div><div class="num mt-0.5">40 °F · 30.05 · 11,500 ft</div></div>
+          <div><div class="eyebrow text-stone-500">KLGU · arrival</div><div class="num mt-0.5">65 °F · 30.10 · 4,457 ft</div></div>
+        </div>
+      </article>
+    </section>
+
+    <!-- STEP 4 — THE CENTERPIECE ──────────────────────────────────────────── -->
+    <section id="step-4" class="relative pl-14 md:pl-20">
+      <div class="absolute left-0 top-3 flex flex-col items-center" aria-hidden="true">
+        <div class="bezel is-warn h-10 w-10 rounded-full flex items-center justify-center font-mono font-bold text-white">4</div>
+      </div>
+
+      <article class="card rounded-lg overflow-hidden">
+        <header class="flex items-start justify-between gap-4 px-5 py-4 border-b border-stone-300/60">
+          <div>
+            <div class="eyebrow text-stone-500">Step 4 — Decision</div>
+            <h2 class="font-display text-2xl tracking-tight" style="font-variation-settings: 'opsz' 60;">Go / No-Go</h2>
+            <p class="text-sm text-stone-600 mt-0.5">A synthesis of runway, density altitude, climb, weather, and qualifications.</p>
+          </div>
+          <span class="shrink-0 inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-bold uppercase tracking-wider" style="background: var(--amber-soft); color: var(--amber); border: 1px solid #e7c885;">
+            <span class="h-1.5 w-1.5 rounded-full" style="background: var(--amber);"></span>
+            1 caution · 1 watch
+          </span>
+        </header>
+
+        <div class="px-5 py-6">
+
+          <!-- ── Verdict slab ─────────────────────────────────────────────── -->
+          <div class="verdict relative rounded-lg px-7 py-7 md:px-9 md:py-8 mb-7 overflow-hidden">
+            <!-- compass rose -->
+            <svg class="rose" viewBox="0 0 100 100" fill="none" stroke="#5a4a2a" stroke-width="1">
+              <circle cx="50" cy="50" r="44" />
+              <circle cx="50" cy="50" r="34" stroke-dasharray="2 4" />
+              <path d="M50 6 L46 50 L54 50 Z" fill="#5a4a2a" stroke="none" />
+              <path d="M50 94 L46 50 L54 50 Z" fill="#bba472" stroke="none" />
+              <path d="M6 50 L50 46 L50 54 Z" fill="#bba472" stroke="none" />
+              <path d="M94 50 L50 46 L50 54 Z" fill="#bba472" stroke="none" />
+              <text x="50" y="14" text-anchor="middle" font-size="10" font-family="B612 Mono, monospace" fill="#5a4a2a">N</text>
+            </svg>
+
+            <div class="flex items-baseline gap-6 flex-wrap">
+              <div>
+                <div class="eyebrow text-amber-800/80">Verdict</div>
+                <div class="verdict-text text-7xl md:text-8xl mt-1 text-amber-900">Review.</div>
+              </div>
+              <div class="max-w-md mt-2">
+                <p class="text-stone-800/90 text-[15px] leading-snug">
+                  Numbers are workable. Two items want a second pair of eyes:
+                  <span class="font-semibold">arrival runway margin at&nbsp;KLGU</span> and an
+                  <span class="font-semibold">AIRMET&nbsp;Tango / Sierra</span> spanning your route.
+                </p>
+              </div>
+            </div>
+
+            <!-- micro-summary chips -->
+            <div class="mt-5 flex flex-wrap gap-1.5">
+              <span class="num eyebrow text-emerald-900 bg-emerald-50/80 border border-emerald-200/80 rounded-full px-2.5 py-1">3 OK</span>
+              <span class="num eyebrow text-amber-900   bg-amber-50/80   border border-amber-200/80   rounded-full px-2.5 py-1">2 CAUTION</span>
+              <span class="num eyebrow text-stone-500   bg-white/60      border border-stone-300/70  rounded-full px-2.5 py-1">0 STOP</span>
+            </div>
+          </div>
+
+          <!-- ── Instrument readout ───────────────────────────────────────── -->
+          <div class="hr-label eyebrow text-xs my-5">Pre-flight instrument readout</div>
+
+          <div class="space-y-2.5">
+
+            <!-- RUNWAY MARGIN — caution -->
+            <a href="#step-3" class="readout-row block">
+              <span class="readout-band warn"></span>
+              <div class="readout-label">
+                <div class="eyebrow text-stone-500">Runway margin</div>
+                <div class="text-xs text-stone-600 mt-0.5">Available − required, both ends</div>
+              </div>
+              <div class="readout-value">
+                <div class="flex items-baseline gap-6 flex-wrap">
+                  <div>
+                    <span class="num text-2xl font-bold text-emerald-800">+1,247</span>
+                    <span class="num text-xs text-stone-500 ml-1">ft</span>
+                    <div class="eyebrow text-stone-500 mt-0.5">KOGD · departure</div>
+                  </div>
+                  <div>
+                    <span class="num text-2xl font-bold text-amber-800">+62</span>
+                    <span class="num text-xs text-stone-500 ml-1">ft</span>
+                    <div class="eyebrow text-stone-500 mt-0.5">KLGU · arrival</div>
+                  </div>
+                </div>
+              </div>
+              <div class="readout-status">
+                <span class="h-2 w-2 rounded-full" style="background: var(--amber);"></span>
+                <span class="eyebrow text-amber-800">Caution</span>
+                <svg class="h-3.5 w-3.5 text-stone-400 ml-auto" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/></svg>
+              </div>
+            </a>
+
+            <!-- DENSITY ALTITUDE — ok -->
+            <a href="#step-3" class="readout-row block">
+              <span class="readout-band ok"></span>
+              <div class="readout-label">
+                <div class="eyebrow text-stone-500">Density altitude</div>
+                <div class="text-xs text-stone-600 mt-0.5">At operating altitude</div>
+              </div>
+              <div class="readout-value">
+                <div>
+                  <span class="num text-2xl font-bold">12,860</span>
+                  <span class="num text-xs text-stone-500 ml-1">ft</span>
+                  <div class="eyebrow text-stone-500 mt-0.5">ISA + 8 °C · within envelope</div>
+                </div>
+              </div>
+              <div class="readout-status">
+                <span class="h-2 w-2 rounded-full" style="background: var(--emerald);"></span>
+                <span class="eyebrow text-emerald-800">OK</span>
+                <svg class="h-3.5 w-3.5 text-stone-400 ml-auto" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/></svg>
+              </div>
+            </a>
+
+            <!-- CLIMB PERFORMANCE — ok -->
+            <a href="#step-3" class="readout-row block">
+              <span class="readout-band ok"></span>
+              <div class="readout-label">
+                <div class="eyebrow text-stone-500">Climb performance</div>
+                <div class="text-xs text-stone-600 mt-0.5">ROC vs. terrain along route</div>
+              </div>
+              <div class="readout-value">
+                <div class="flex items-baseline gap-5 flex-wrap">
+                  <div>
+                    <span class="num text-2xl font-bold">+428</span>
+                    <span class="num text-xs text-stone-500 ml-1">fpm</span>
+                    <div class="eyebrow text-stone-500 mt-0.5">Cruise climb</div>
+                  </div>
+                  <div>
+                    <span class="num text-2xl font-bold text-emerald-800">+1,247</span>
+                    <span class="num text-xs text-stone-500 ml-1">ft</span>
+                    <div class="eyebrow text-stone-500 mt-0.5">Clears highest obstacle</div>
+                  </div>
+                </div>
+              </div>
+              <div class="readout-status">
+                <span class="h-2 w-2 rounded-full" style="background: var(--emerald);"></span>
+                <span class="eyebrow text-emerald-800">OK</span>
+                <svg class="h-3.5 w-3.5 text-stone-400 ml-auto" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/></svg>
+              </div>
+            </a>
+
+            <!-- WEATHER — caution -->
+            <a href="#step-2" class="readout-row block">
+              <span class="readout-band warn"></span>
+              <div class="readout-label">
+                <div class="eyebrow text-stone-500">Weather advisories</div>
+                <div class="text-xs text-stone-600 mt-0.5">In route corridor &amp; area of ops</div>
+              </div>
+              <div class="readout-value">
+                <div class="flex items-baseline gap-2 flex-wrap">
+                  <span class="num text-base font-bold uppercase tracking-wider px-1.5 py-0.5 rounded" style="background: var(--amber-soft); color: var(--amber);">AIRMET Tango</span>
+                  <span class="num text-base font-bold uppercase tracking-wider px-1.5 py-0.5 rounded" style="background: var(--amber-soft); color: var(--amber);">AIRMET Sierra</span>
+                </div>
+                <div class="text-xs text-stone-600 mt-1.5">Moderate turbulence below FL180; mountain obscuration along ridge line.</div>
+              </div>
+              <div class="readout-status">
+                <span class="h-2 w-2 rounded-full" style="background: var(--amber);"></span>
+                <span class="eyebrow text-amber-800">Caution</span>
+                <svg class="h-3.5 w-3.5 text-stone-400 ml-auto" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/></svg>
+              </div>
+            </a>
+
+            <!-- QUALS — ok -->
+            <a href="#step-1" class="readout-row block">
+              <span class="readout-band ok"></span>
+              <div class="readout-label">
+                <div class="eyebrow text-stone-500">Pilot qualifications</div>
+                <div class="text-xs text-stone-600 mt-0.5">Required for this sortie</div>
+              </div>
+              <div class="readout-value">
+                <div class="flex items-baseline gap-5 flex-wrap">
+                  <div class="flex items-baseline gap-1.5">
+                    <span class="num text-emerald-800 font-bold">✓</span>
+                    <span class="num text-sm">CAPF 70-5</span>
+                    <span class="text-xs text-stone-500">mountain endorsement</span>
+                  </div>
+                  <div class="flex items-baseline gap-1.5">
+                    <span class="num text-emerald-800 font-bold">✓</span>
+                    <span class="num text-sm">CAPF 70-91 §V</span>
+                    <span class="text-xs text-stone-500">+ mtn cert</span>
+                  </div>
+                </div>
+              </div>
+              <div class="readout-status">
+                <span class="h-2 w-2 rounded-full" style="background: var(--emerald);"></span>
+                <span class="eyebrow text-emerald-800">OK</span>
+                <svg class="h-3.5 w-3.5 text-stone-400 ml-auto" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/></svg>
+              </div>
+            </a>
+
+          </div>
+
+          <!-- ── Action row ───────────────────────────────────────────────── -->
+          <div class="mt-7 flex flex-wrap items-center justify-between gap-3 pt-5 border-t border-dashed border-stone-300/80">
+            <div class="text-xs text-stone-500 max-w-md">
+              <span class="eyebrow text-stone-600">Pilot acknowledgment</span><br>
+              I have reviewed each item above and am satisfied with the cautions before commencing this sortie.
+            </div>
+            <div class="flex flex-wrap items-center gap-2">
+              <button class="rounded-md border border-stone-300/80 bg-white/70 px-4 py-2 text-sm font-medium hover:bg-white">Print briefing</button>
+              <button class="rounded-md px-4 py-2 text-sm font-bold text-white" style="background: var(--ink); box-shadow: 0 2px 0 -0.5px rgba(0,0,0,0.18);">
+                Acknowledge &amp; proceed
+              </button>
+            </div>
+          </div>
+
+          <!-- ── Collapsed detailed calculations ─────────────────────────── -->
+          <details class="mt-6 rounded-lg border border-stone-300/70 bg-white/60">
+            <summary class="cursor-pointer select-none px-4 py-3 text-sm font-medium text-stone-700 flex items-center justify-between hover:bg-white/80 rounded-lg">
+              <span class="flex items-center gap-2">
+                <svg class="h-3.5 w-3.5 text-stone-500" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/></svg>
+                Detailed calculations
+              </span>
+              <span class="eyebrow text-stone-500 font-normal">Altitudes · Climb · TOLD · Maneuvering</span>
+            </summary>
+            <div class="px-4 pb-4 text-sm text-stone-500 italic">
+              The existing <span class="not-italic num text-stone-700">Altitudes</span>,
+              <span class="not-italic num text-stone-700">ClimbPerformance</span>,
+              <span class="not-italic num text-stone-700">TakeoffPerformance</span>, and
+              <span class="not-italic num text-stone-700">ManeuveringPerformance</span> tables nest here — unchanged.
+            </div>
+          </details>
+
+        </div>
+      </article>
+    </section>
+
+  </main>
+
+  <footer class="mx-auto max-w-5xl px-5 md:px-7 pb-10 pt-2 mt-10">
+    <div class="ticks mb-3"></div>
+    <div class="flex items-baseline justify-between text-xs text-stone-500">
+      <div class="eyebrow">Mountain worksheet — decision panel mockup · v2</div>
+      <div class="num">10 May 2026 · 14:32z</div>
+    </div>
+  </footer>
+
+  <script>
+    // Active step pill follows the section in view
+    const links = document.querySelectorAll('.step-link');
+    const setActive = (id) => {
+      links.forEach((l) => l.classList.toggle('is-active', l.dataset.step === id));
+    };
+    setActive('step-4');
+    const observer = new IntersectionObserver((entries) => {
+      entries
+        .filter((e) => e.isIntersecting)
+        .sort((a, b) => a.target.getBoundingClientRect().top - b.target.getBoundingClientRect().top)
+        .forEach((e) => setActive(e.target.id));
+    }, { rootMargin: '-30% 0px -60% 0px', threshold: 0 });
+    document.querySelectorAll('section[id^="step-"]').forEach((s) => observer.observe(s));
+  </script>
+</body>
+</html>

--- a/docs/numbered-step-shell-mockup.html
+++ b/docs/numbered-step-shell-mockup.html
@@ -1,0 +1,841 @@
+<!DOCTYPE html>
+<html lang="en" class="bg-slate-100">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Mountain Worksheet — Numbered Step Shell (mockup)</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    body { font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif; }
+    .num-mono { font-variant-numeric: tabular-nums; font-family: ui-monospace, "SF Mono", Menlo, monospace; }
+    /* Smooth scroll past the sticky stepper + action bar (~ 44 + 56 + a little) */
+    section[id^="step-"] { scroll-margin-top: 116px; }
+
+    /* Sticky action bar — its state is driven by [data-state] on the body */
+    .action-bar-state { display: none; }
+    body[data-state="incomplete"] .action-bar-state[data-state="incomplete"],
+    body[data-state="ready"]      .action-bar-state[data-state="ready"],
+    body[data-state="fetched"]    .action-bar-state[data-state="fetched"],
+    body[data-state="all-done"]   .action-bar-state[data-state="all-done"] { display: flex; }
+
+    /* Left-edge color band per state */
+    body[data-state="incomplete"] #action-bar { border-left: 4px solid #f59e0b; }
+    body[data-state="ready"]      #action-bar { border-left: 4px solid #10b981; }
+    body[data-state="fetched"]    #action-bar { border-left: 4px solid #94a3b8; }
+    body[data-state="all-done"]   #action-bar { border-left: 4px solid #0f172a; }
+
+    /* Pulse for the primary "ready" state — draws the eye */
+    @keyframes pulse-ring {
+      0%, 100% { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.45); }
+      50%      { box-shadow: 0 0 0 6px rgba(16, 185, 129, 0); }
+    }
+    .pulse-ring { animation: pulse-ring 1.8s ease-in-out infinite; }
+
+    /* Demo cycler chip */
+    .demo-chip {
+      position: fixed; right: 16px; bottom: 16px; z-index: 40;
+      background: rgba(15, 23, 42, 0.92);
+      color: #fff;
+      font-family: ui-sans-serif, system-ui, sans-serif;
+      font-size: 12px;
+      border-radius: 999px;
+      padding: 8px 12px;
+      box-shadow: 0 8px 24px -8px rgba(0,0,0,0.4);
+      display: flex; align-items: center; gap: 8px;
+      backdrop-filter: blur(4px);
+    }
+    .demo-chip button {
+      background: rgba(255,255,255,0.1);
+      border: 1px solid rgba(255,255,255,0.18);
+      color: #fff;
+      border-radius: 999px;
+      padding: 2px 8px;
+      font-size: 11px;
+      cursor: pointer;
+    }
+    .demo-chip button:hover { background: rgba(255,255,255,0.18); }
+    .demo-chip .demo-state-label {
+      font-variant-numeric: tabular-nums;
+      font-family: ui-monospace, monospace;
+      letter-spacing: 0.02em;
+      color: #fef3c7;
+      min-width: 88px;
+      text-align: center;
+    }
+
+    /* ── Slide-over overlay (Instructions, Checklist) ─────────────────── */
+    .slideover-backdrop {
+      position: fixed; inset: 0; z-index: 40;
+      background: rgba(15, 23, 42, 0.42);
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 220ms ease;
+    }
+    body[data-overlay]:not([data-overlay=""]) .slideover-backdrop {
+      opacity: 1;
+      pointer-events: auto;
+    }
+    .slideover {
+      position: fixed;
+      top: 0; right: 0; bottom: 0;
+      width: 100%;
+      max-width: 36rem;
+      background: #fff;
+      z-index: 50;
+      box-shadow: -16px 0 40px -16px rgba(15, 23, 42, 0.25);
+      transform: translateX(100%);
+      transition: transform 280ms cubic-bezier(0.32, 0.72, 0, 1);
+      display: flex;
+      flex-direction: column;
+      border-left: 1px solid #e2e8f0;
+    }
+    body[data-overlay="instructions"] .slideover[data-name="instructions"],
+    body[data-overlay="checklist"]    .slideover[data-name="checklist"]    { transform: translateX(0); }
+    .slideover-header {
+      padding: 1rem 1.25rem;
+      border-bottom: 1px solid #e2e8f0;
+      display: flex; align-items: center; justify-content: space-between; gap: 1rem;
+      flex-shrink: 0;
+      background: #f8fafc;
+    }
+    .slideover-body {
+      flex: 1;
+      overflow-y: auto;
+      padding: 1.25rem;
+      font-size: 0.875rem;
+      color: #334155;
+      line-height: 1.5;
+    }
+    .slideover-body h3 {
+      font-weight: 600; color: #0f172a;
+      margin-top: 1.5rem; margin-bottom: 0.5rem;
+      font-size: 0.9375rem;
+    }
+    .slideover-body > :first-child { margin-top: 0; }
+    .slideover-body h3:first-child { margin-top: 0; }
+    .slideover-body p { margin-bottom: 0.75rem; }
+    .slideover-body p:last-child { margin-bottom: 0; }
+    .slideover-body ul { padding-left: 1.25rem; list-style: disc; }
+    .slideover-body ul li + li { margin-top: 0.3rem; }
+    .slideover-body strong { color: #0f172a; font-weight: 600; }
+    .slideover-body a { color: #2563eb; }
+    .slideover-body a:hover { text-decoration: underline; }
+    .slideover-body table { font-size: 0.75rem; width: 100%; }
+
+    /* Lock body scroll when overlay open */
+    body[data-overlay]:not([data-overlay=""]) { overflow: hidden; }
+
+    /* Print: expand slide-overs as appendices, hide screen-only chrome */
+    @media print {
+      .slideover-backdrop { display: none; }
+      .slideover {
+        position: static;
+        transform: none !important;
+        max-width: none;
+        width: 100%;
+        box-shadow: none;
+        border-left: none;
+        page-break-before: always;
+      }
+      .slideover-header { display: none; }
+      .slideover-body { padding: 0; }
+      .demo-chip { display: none !important; }
+      nav#stepper, #action-bar { position: static !important; }
+    }
+  </style>
+</head>
+<body class="min-h-screen text-slate-900" data-state="ready">
+
+  <!-- ── Header — slim utility chrome only ───────────────────────────────── -->
+  <header class="bg-slate-900 text-white shadow-md">
+    <div class="mx-auto flex w-full max-w-5xl items-center justify-between gap-4 px-4 py-3.5 md:px-6">
+      <div class="flex items-baseline gap-3 min-w-0">
+        <h1 class="text-2xl md:text-[28px] font-bold tracking-tight truncate">Mountain Flying Worksheet</h1>
+        <span class="hidden md:inline text-slate-500">·</span>
+        <span class="hidden md:inline num-mono text-sm text-slate-300">14:32:08z · Sun 10 May 2026</span>
+      </div>
+      <div class="flex items-center gap-1.5 shrink-0">
+        <button data-overlay-toggle="instructions" class="rounded-md p-1.5 text-slate-300 hover:text-white hover:bg-slate-800 border border-slate-700/60 flex items-center" title="Instructions &amp; operational notes" aria-label="Open instructions">
+          <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="2.25" viewBox="0 0 24 24">
+            <circle cx="12" cy="12" r="9.5"/>
+            <path stroke-linecap="round" stroke-linejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M12 16.5h.008v.008H12V16.5z"/>
+          </svg>
+        </button>
+        <button class="rounded-md px-2.5 py-1 text-xs text-slate-300 hover:text-white hover:bg-slate-800 border border-slate-700/60">Reset</button>
+        <button class="rounded-md px-2.5 py-1 text-xs text-slate-300 hover:text-white hover:bg-slate-800 border border-slate-700/60 flex items-center gap-1.5">
+          <svg class="h-3 w-3" fill="none" stroke="currentColor" stroke-width="2.25" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M13.828 10.172a4 4 0 015.656 5.656l-3 3a4 4 0 01-5.656-5.656m-2 2a4 4 0 01-5.656-5.656l3-3a4 4 0 015.656 5.656"/></svg>
+          Copy link
+        </button>
+        <button class="rounded-md px-2.5 py-1 text-xs border border-slate-700/60 num-mono flex items-center gap-1">
+          <span class="text-slate-500">°C</span>
+          <span class="text-slate-600">|</span>
+          <span class="text-white font-semibold">°F</span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <!-- ── Sticky stepper ───────────────────────────────────────────────────── -->
+  <nav id="stepper" class="sticky top-0 z-20 border-b border-slate-200 bg-slate-50/95 backdrop-blur supports-[backdrop-filter]:bg-slate-50/75">
+    <div class="mx-auto max-w-5xl px-4 py-2.5 md:px-6">
+      <ol class="flex items-center gap-1.5 overflow-x-auto text-sm">
+        <li class="shrink-0">
+          <a href="#step-1" data-step="1" class="step-link flex items-center gap-2 rounded-full bg-white px-3 py-1.5 transition-all">
+            <span class="num-mono flex h-6 w-6 items-center justify-center rounded-full bg-slate-900 text-white text-xs font-semibold">1</span>
+            <span class="font-medium text-slate-900">Sortie Details</span>
+            <span class="text-xs text-amber-600 font-medium">8 of 11</span>
+          </a>
+        </li>
+        <li aria-hidden="true" class="text-slate-300">›</li>
+        <li class="shrink-0">
+          <a href="#step-2" data-step="2" class="step-link flex items-center gap-2 rounded-full bg-white px-3 py-1.5 transition-all">
+            <span class="num-mono flex h-6 w-6 items-center justify-center rounded-full bg-emerald-500 text-white text-xs font-semibold">2</span>
+            <span class="text-slate-700">Weather</span>
+            <span class="text-xs text-emerald-600 font-medium">●</span>
+          </a>
+        </li>
+        <li aria-hidden="true" class="text-slate-300">›</li>
+        <li class="shrink-0">
+          <a href="#step-3" data-step="3" class="step-link flex items-center gap-2 rounded-full bg-white px-3 py-1.5 transition-all">
+            <span class="num-mono flex h-6 w-6 items-center justify-center rounded-full bg-amber-500 text-white text-xs font-semibold">3</span>
+            <span class="text-slate-700">Decision</span>
+            <span class="text-xs text-amber-600 font-medium">⚠ 1</span>
+          </a>
+        </li>
+      </ol>
+    </div>
+  </nav>
+
+  <!-- ── Sticky "next action" bar ─────────────────────────────────────────── -->
+  <div id="action-bar" class="sticky top-[44px] z-20 bg-white border-b border-slate-200 shadow-[0_1px_0_rgba(15,23,42,0.04),0_4px_8px_-6px_rgba(15,23,42,0.18)]">
+    <div class="mx-auto max-w-5xl px-4 md:px-6 py-2.5 flex items-center justify-between gap-4">
+
+      <!-- STATE: incomplete ───────────────────────────────────────────────── -->
+      <div class="action-bar-state items-center gap-3 flex-1 min-w-0" data-state="incomplete">
+        <svg class="h-4 w-4 text-amber-500 shrink-0" fill="none" stroke="currentColor" stroke-width="2.25" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z"/></svg>
+        <div class="min-w-0">
+          <div class="text-sm font-medium text-slate-900">Add departure airport &amp; time to fetch weather</div>
+          <div class="text-xs text-amber-700">Step 1 — 8 of 11 fields complete</div>
+        </div>
+      </div>
+      <div class="action-bar-state items-center gap-2 shrink-0" data-state="incomplete">
+        <button disabled class="flex items-center gap-2 rounded-md bg-slate-100 text-slate-400 px-3.5 py-2 text-sm font-medium border border-slate-200 cursor-not-allowed">
+          <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M3 15a4 4 0 004 4h10a5 5 0 100-10 7 7 0 00-13.5 2A4 4 0 003 15z"/></svg>
+          Fetch weather
+        </button>
+      </div>
+
+      <!-- STATE: ready ────────────────────────────────────────────────────── -->
+      <div class="action-bar-state items-center gap-3 flex-1 min-w-0" data-state="ready">
+        <svg class="h-4 w-4 text-emerald-600 shrink-0" fill="none" stroke="currentColor" stroke-width="2.25" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+        <div class="min-w-0">
+          <div class="text-sm font-medium text-slate-900">Sortie details ready</div>
+          <div class="text-xs text-slate-600">KOGD → KLGU · departing 18:00z · ready to fetch weather</div>
+        </div>
+      </div>
+      <div class="action-bar-state items-center gap-2 shrink-0" data-state="ready">
+        <button class="pulse-ring flex items-center gap-2 rounded-md bg-emerald-500 hover:bg-emerald-600 text-white px-4 py-2 text-sm font-semibold shadow">
+          <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M3 15a4 4 0 004 4h10a5 5 0 100-10 7 7 0 00-13.5 2A4 4 0 003 15z"/></svg>
+          Fetch weather
+          <svg class="h-4 w-4 -mr-0.5" fill="none" stroke="currentColor" stroke-width="2.25" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3"/></svg>
+        </button>
+      </div>
+
+      <!-- STATE: fetched ──────────────────────────────────────────────────── -->
+      <div class="action-bar-state items-center gap-3 flex-1 min-w-0" data-state="fetched">
+        <svg class="h-4 w-4 text-emerald-600 shrink-0" fill="none" stroke="currentColor" stroke-width="2.25" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+        <div class="min-w-0">
+          <div class="text-sm font-medium text-slate-900">Weather fetched · <span class="num-mono text-slate-700">14:31z</span> <span class="text-slate-500">(1 min ago)</span></div>
+          <div class="text-xs text-slate-600">Review the weather below, then proceed to the decision.</div>
+        </div>
+      </div>
+      <div class="action-bar-state items-center gap-2 shrink-0" data-state="fetched">
+        <button class="flex items-center gap-1.5 rounded-md text-slate-600 hover:text-slate-900 hover:bg-slate-100 px-3 py-1.5 text-xs font-medium border border-slate-300 num-mono">
+          <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992V4.356M3 11.999A8.96 8.96 0 0114.946 4.51L21 7.51m-18 9a8.96 8.96 0 0014.946 1.99L21 15"/></svg>
+          Re-fetch
+        </button>
+        <a href="#step-3" class="flex items-center gap-1.5 rounded-md bg-slate-900 hover:bg-slate-800 text-white px-3.5 py-1.5 text-sm font-medium">
+          Review decision
+          <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5"/></svg>
+        </a>
+      </div>
+
+      <!-- STATE: all-done ─────────────────────────────────────────────────── -->
+      <div class="action-bar-state items-center gap-3 flex-1 min-w-0" data-state="all-done">
+        <svg class="h-4 w-4 text-slate-900 shrink-0" fill="none" stroke="currentColor" stroke-width="2.25" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M11.48 3.499a.562.562 0 011.04 0l2.125 5.111a.563.563 0 00.475.345l5.518.442c.499.04.701.663.32.988l-4.204 3.602a.563.563 0 00-.182.557l1.285 5.385a.562.562 0 01-.84.61l-4.725-2.885a.563.563 0 00-.586 0L6.982 20.54a.562.562 0 01-.84-.61l1.285-5.386a.562.562 0 00-.182-.557l-4.204-3.602a.562.562 0 01.321-.988l5.518-.442a.563.563 0 00.475-.345L11.48 3.5z"/></svg>
+        <div class="min-w-0">
+          <div class="text-sm font-medium text-slate-900">All checks complete — verdict ready for review</div>
+          <div class="text-xs text-amber-700">⚠ 1 caution · 1 watch — review the Go / No-Go panel below before acknowledging</div>
+        </div>
+      </div>
+      <div class="action-bar-state items-center gap-2 shrink-0" data-state="all-done">
+        <button class="flex items-center gap-1.5 rounded-md bg-slate-100 hover:bg-slate-200 text-slate-700 px-3 py-1.5 text-xs font-medium border border-slate-300">
+          <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M6.72 13.829c-.24.03-.48.062-.72.096m.72-.096a42.415 42.415 0 0110.56 0m-10.56 0L6.34 18m10.94-4.171c.24.03.48.062.72.096m-.72-.096L17.66 18m0 0l.229 2.523a1.125 1.125 0 01-1.12 1.227H7.231c-.662 0-1.18-.568-1.12-1.227L6.34 18m11.318 0h1.091A2.25 2.25 0 0021 15.75V9.456c0-1.081-.768-2.015-1.837-2.175a48.055 48.055 0 00-1.913-.247M6.34 18H5.25A2.25 2.25 0 013 15.75V9.456c0-1.081.768-2.015 1.837-2.175a48.041 48.041 0 011.913-.247m10.5 0a48.536 48.536 0 00-10.5 0m10.5 0V3.375c0-.621-.504-1.125-1.125-1.125h-8.25c-.621 0-1.125.504-1.125 1.125v3.659"/></svg>
+          Print briefing
+        </button>
+        <button class="flex items-center gap-2 rounded-md bg-slate-900 hover:bg-slate-800 text-white px-4 py-2 text-sm font-semibold shadow">
+          <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2.25" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+          Acknowledge &amp; proceed
+        </button>
+      </div>
+
+      <!-- Persistent: Checklist trigger (always visible across all states) -->
+      <div class="shrink-0 pl-2.5 ml-0.5 border-l border-slate-200 flex items-center">
+        <button data-overlay-toggle="checklist" class="flex items-center gap-1.5 rounded-md text-slate-600 hover:text-slate-900 hover:bg-slate-100 px-2.5 py-1.5 text-xs font-medium border border-slate-300" title="Open Mountain Flying Checklist">
+          <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"/>
+          </svg>
+          Checklist
+        </button>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- ── Main ─────────────────────────────────────────────────────────────── -->
+  <main class="mx-auto max-w-5xl px-4 md:px-6 py-8 space-y-6">
+
+    <!-- STEP 1 ─────────────────────────────────────────────── -->
+    <section id="step-1" class="relative pl-14 md:pl-16">
+      <div class="absolute left-0 top-0 bottom-0 flex flex-col items-center" aria-hidden="true">
+        <div class="num-mono flex h-10 w-10 items-center justify-center rounded-full bg-slate-900 text-white font-bold text-base shadow ring-4 ring-slate-100">1</div>
+        <div class="mt-2 w-px flex-1 bg-slate-300"></div>
+      </div>
+      <article class="rounded-xl border border-slate-200 bg-white shadow-sm overflow-hidden">
+        <header class="flex items-start justify-between gap-4 border-b border-slate-200 px-5 py-4">
+          <div>
+            <h2 class="text-xl font-bold tracking-tight">Sortie Details</h2>
+            <p class="text-sm text-slate-500 mt-0.5">Who's flying, when, and where</p>
+          </div>
+          <span class="shrink-0 inline-flex items-center gap-1.5 rounded-full bg-amber-50 text-amber-700 border border-amber-200 px-2.5 py-1 text-xs font-medium">
+            <span class="h-1.5 w-1.5 rounded-full bg-amber-500"></span>
+            8 of 11 fields
+          </span>
+        </header>
+        <div class="px-5 py-5 space-y-6">
+
+          <div>
+            <h3 class="text-xs font-semibold uppercase tracking-wider text-slate-500 mb-3">Pilot &amp; Aircraft</h3>
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <div>
+                <label class="block text-sm font-medium mb-1">Pilot Name</label>
+                <input value="J. Loosli" class="w-full rounded-md border border-slate-300 px-3 py-2 text-sm">
+              </div>
+              <div>
+                <label class="block text-sm font-medium mb-1">Aircraft Model</label>
+                <select class="w-full rounded-md border border-slate-300 px-3 py-2 text-sm bg-white">
+                  <option>C172S (180 HP)</option>
+                </select>
+              </div>
+              <div>
+                <label class="block text-sm font-medium mb-1">Tail Number</label>
+                <input value="N12345" class="w-full rounded-md border border-slate-300 px-3 py-2 text-sm uppercase">
+              </div>
+            </div>
+          </div>
+
+          <div>
+            <h3 class="text-xs font-semibold uppercase tracking-wider text-slate-500 mb-3">When</h3>
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <div>
+                <label class="block text-sm font-medium mb-1">Date</label>
+                <input type="date" value="2026-05-10" class="w-full rounded-md border border-slate-300 px-3 py-2 text-sm">
+              </div>
+              <div>
+                <label class="block text-sm font-medium mb-1">Time (UTC)</label>
+                <select class="w-full rounded-md border border-slate-300 px-3 py-2 text-sm bg-white">
+                  <option>1800</option>
+                </select>
+              </div>
+              <div>
+                <label class="block text-sm font-medium mb-1">Duration (hrs)</label>
+                <select class="w-full rounded-md border border-slate-300 px-3 py-2 text-sm bg-white">
+                  <option>2.0</option>
+                </select>
+              </div>
+            </div>
+            <div class="mt-3 flex flex-wrap items-center gap-2 text-sm">
+              <span class="inline-flex items-center rounded-full bg-emerald-50 text-emerald-700 border border-emerald-200 px-2.5 py-0.5 text-xs font-medium">In 3 h 28 min</span>
+              <span class="text-slate-600 num-mono text-xs">12:00 local · UTC−6 · Sun 10 May</span>
+            </div>
+          </div>
+
+          <div>
+            <h3 class="text-xs font-semibold uppercase tracking-wider text-slate-500 mb-3">Where</h3>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <label class="block text-sm font-medium mb-1">Departure Airport</label>
+                <input value="KOGD" class="w-full rounded-md border border-slate-300 px-3 py-2 text-sm uppercase num-mono">
+              </div>
+              <div>
+                <label class="block text-sm font-medium mb-1">Arrival Airport</label>
+                <input value="KLGU" class="w-full rounded-md border border-slate-300 px-3 py-2 text-sm uppercase num-mono">
+              </div>
+              <div class="md:col-span-2">
+                <label class="block text-sm font-medium mb-1">
+                  Area of Operations
+                  <span class="text-xs text-slate-500 font-normal">— lat/lon, VOR radial, or airport radial</span>
+                </label>
+                <input value="KOGD/285/34" class="w-full rounded-md border border-slate-300 px-3 py-2 text-sm num-mono">
+              </div>
+              <div>
+                <label class="block text-sm font-medium mb-1">Operating Altitude (MSL ft)</label>
+                <input type="number" value="11500" class="w-full rounded-md border border-slate-300 px-3 py-2 text-sm num-mono">
+              </div>
+              <div>
+                <label class="block text-sm font-medium mb-1">Takeoff Weight (lbs)</label>
+                <input type="number" value="2400" class="w-full rounded-md border border-slate-300 px-3 py-2 text-sm num-mono">
+              </div>
+            </div>
+          </div>
+
+          <div>
+            <h3 class="text-xs font-semibold uppercase tracking-wider text-slate-500 mb-3">Pilot Qualifications</h3>
+            <div class="space-y-2 text-sm">
+              <label class="flex items-center gap-2">
+                <input type="checkbox" checked class="rounded">
+                <span>Current CAPF 70-5 Mountain Flight Endorsement</span>
+              </label>
+              <label class="flex items-center gap-2">
+                <input type="checkbox" class="rounded">
+                <span>Current CAPF 70-91 §V signoff + Mountain Flying Certification</span>
+                <span class="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded px-1.5 py-0.5">Required for mountain search</span>
+              </label>
+            </div>
+          </div>
+
+        </div>
+      </article>
+    </section>
+
+    <!-- STEP 2 ─────────────────────────────────────────────── -->
+    <section id="step-2" class="relative pl-14 md:pl-16">
+      <div class="absolute left-0 top-0 bottom-0 flex flex-col items-center" aria-hidden="true">
+        <div class="num-mono flex h-10 w-10 items-center justify-center rounded-full bg-emerald-500 text-white font-bold text-base shadow ring-4 ring-slate-100">2</div>
+        <div class="mt-2 w-px flex-1 bg-slate-300"></div>
+      </div>
+      <article class="rounded-xl border border-slate-200 bg-white shadow-sm overflow-hidden">
+        <header class="flex items-start justify-between gap-4 border-b border-slate-200 px-5 py-4">
+          <div>
+            <h2 class="text-xl font-bold tracking-tight">Weather</h2>
+            <p class="text-sm text-slate-500 mt-0.5">Winds aloft, terminal conditions, and advisories</p>
+          </div>
+          <span class="shrink-0 inline-flex items-center gap-1.5 rounded-full bg-emerald-50 text-emerald-700 border border-emerald-200 px-2.5 py-1 text-xs font-medium">
+            <span class="h-1.5 w-1.5 rounded-full bg-emerald-500"></span>
+            Fetched 14:31 UTC
+          </span>
+        </header>
+        <div class="px-5 py-5 space-y-6">
+
+          <div class="inline-flex items-center gap-2 rounded-md bg-blue-50 border border-blue-200 text-blue-900 px-2.5 py-1 text-xs">
+            <span class="inline-block h-3 w-3 rounded-sm bg-blue-100 border border-blue-400"></span>
+            Blue cells fetched from <span class="font-semibold">aviationweather.gov</span> — type to override
+          </div>
+
+          <div>
+            <h3 class="text-xs font-semibold uppercase tracking-wider text-slate-500 mb-3">Aloft</h3>
+            <div class="overflow-x-auto">
+              <table class="w-full border-collapse text-sm">
+                <thead>
+                  <tr class="bg-slate-100 text-slate-700">
+                    <th class="border border-slate-200 p-2 text-left font-semibold"></th>
+                    <th class="border border-slate-200 p-2 num-mono">3,000′</th>
+                    <th class="border border-slate-200 p-2 num-mono">6,000′</th>
+                    <th class="border border-slate-200 p-2 num-mono">9,000′</th>
+                    <th class="border border-slate-200 p-2 num-mono">12,000′</th>
+                    <th class="border border-slate-200 p-2 num-mono">15,000′</th>
+                  </tr>
+                </thead>
+                <tbody class="num-mono">
+                  <tr>
+                    <td class="border border-slate-200 p-2 font-sans">Wind Dir (°)</td>
+                    <td class="border border-slate-200 p-1"><input class="w-full text-center bg-blue-50 border border-blue-300 rounded p-1" value="280"></td>
+                    <td class="border border-slate-200 p-1"><input class="w-full text-center bg-blue-50 border border-blue-300 rounded p-1" value="290"></td>
+                    <td class="border border-slate-200 p-1"><input class="w-full text-center bg-blue-50 border border-blue-300 rounded p-1" value="300"></td>
+                    <td class="border border-slate-200 p-1"><input class="w-full text-center bg-blue-50 border border-blue-300 rounded p-1" value="310"></td>
+                    <td class="border border-slate-200 p-1"><input class="w-full text-center bg-blue-50 border border-blue-300 rounded p-1" value="320"></td>
+                  </tr>
+                  <tr>
+                    <td class="border border-slate-200 p-2 font-sans">Wind Vel (kt)</td>
+                    <td class="border border-slate-200 p-1"><input class="w-full text-center bg-blue-50 border border-blue-300 rounded p-1" value="12"></td>
+                    <td class="border border-slate-200 p-1"><input class="w-full text-center bg-blue-50 border border-blue-300 rounded p-1" value="18"></td>
+                    <td class="border border-slate-200 p-1"><input class="w-full text-center bg-blue-50 border border-blue-300 rounded p-1" value="25"></td>
+                    <td class="border border-slate-200 p-1"><input class="w-full text-center bg-blue-50 border border-blue-300 rounded p-1" value="32"></td>
+                    <td class="border border-slate-200 p-1"><input class="w-full text-center bg-blue-50 border border-blue-300 rounded p-1" value="38"></td>
+                  </tr>
+                  <tr>
+                    <td class="border border-slate-200 p-2 font-sans">Temp (°F)</td>
+                    <td class="border border-slate-200 p-1"><input class="w-full text-center bg-blue-50 border border-blue-300 rounded p-1" value="48"></td>
+                    <td class="border border-slate-200 p-1"><input class="w-full text-center bg-blue-50 border border-blue-300 rounded p-1" value="38"></td>
+                    <td class="border border-slate-200 p-1"><input class="w-full text-center bg-blue-50 border border-blue-300 rounded p-1" value="28"></td>
+                    <td class="border border-slate-200 p-1"><input class="w-full text-center bg-blue-50 border border-blue-300 rounded p-1" value="18"></td>
+                    <td class="border border-slate-200 p-1"><input class="w-full text-center bg-blue-50 border border-blue-300 rounded p-1" value="08"></td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          <div>
+            <h3 class="text-xs font-semibold uppercase tracking-wider text-slate-500 mb-3">At airports</h3>
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
+
+              <!-- Departure card ─────────────────────────────────────────── -->
+              <div class="rounded-lg border border-slate-200 bg-white overflow-hidden">
+                <header class="px-4 py-2 bg-slate-50 border-b border-slate-200 flex items-baseline justify-between gap-2">
+                  <span class="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Departure</span>
+                  <span class="num-mono text-sm font-semibold text-slate-900">KOGD</span>
+                </header>
+                <div class="px-4 py-3 space-y-2.5">
+                  <div class="flex items-center justify-between gap-2">
+                    <span class="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Temperature</span>
+                    <input class="num-mono text-right bg-blue-50 border border-blue-300 rounded px-2 py-1 w-24 text-sm" value="68 °F">
+                  </div>
+                  <div class="flex items-center justify-between gap-2">
+                    <span class="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Altimeter</span>
+                    <input class="num-mono text-right bg-blue-50 border border-blue-300 rounded px-2 py-1 w-24 text-sm" value="30.12">
+                  </div>
+                  <div class="border-t border-dashed border-slate-200 -mx-4"></div>
+                  <div class="flex items-center justify-between gap-2">
+                    <span class="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Field elev</span>
+                    <span class="num-mono text-sm text-slate-900">4,473 ft</span>
+                  </div>
+                  <div class="flex items-center justify-between gap-2">
+                    <span class="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Runway</span>
+                    <select class="num-mono text-right bg-white border border-slate-300 rounded px-2 py-1 text-sm">
+                      <option>16/34 · 5,500 ft</option>
+                      <option>03/21 · 8,103 ft</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Operating card ─────────────────────────────────────────── -->
+              <div class="rounded-lg border border-slate-200 bg-white overflow-hidden">
+                <header class="px-4 py-2 bg-slate-50 border-b border-slate-200 flex items-baseline justify-between gap-2">
+                  <span class="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Operating</span>
+                  <span class="text-xs text-slate-500">Cruise · area of ops</span>
+                </header>
+                <div class="px-4 py-3 space-y-2.5">
+                  <div class="flex items-center justify-between gap-2">
+                    <span class="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Temperature</span>
+                    <input class="num-mono text-right bg-blue-50 border border-blue-300 rounded px-2 py-1 w-24 text-sm" value="40 °F">
+                  </div>
+                  <div class="flex items-center justify-between gap-2">
+                    <span class="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Altimeter</span>
+                    <input class="num-mono text-right bg-blue-50 border border-blue-300 rounded px-2 py-1 w-24 text-sm" value="30.05">
+                  </div>
+                  <div class="border-t border-dashed border-slate-200 -mx-4"></div>
+                  <div class="flex items-center justify-between gap-2">
+                    <span class="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Altitude</span>
+                    <a href="#step-1" class="num-mono text-sm text-slate-900 inline-flex items-center gap-1 hover:text-slate-600 group" title="Set in Sortie Details">
+                      11,500 ft
+                      <svg class="h-3 w-3 text-slate-400 group-hover:text-slate-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M7 17L17 7M9 7h8v8"/></svg>
+                    </a>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Arrival card ───────────────────────────────────────────── -->
+              <div class="rounded-lg border border-slate-200 bg-white overflow-hidden">
+                <header class="px-4 py-2 bg-slate-50 border-b border-slate-200 flex items-baseline justify-between gap-2">
+                  <span class="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Arrival</span>
+                  <span class="num-mono text-sm font-semibold text-slate-900">KLGU</span>
+                </header>
+                <div class="px-4 py-3 space-y-2.5">
+                  <div class="flex items-center justify-between gap-2">
+                    <span class="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Temperature</span>
+                    <input class="num-mono text-right bg-blue-50 border border-blue-300 rounded px-2 py-1 w-24 text-sm" value="65 °F">
+                  </div>
+                  <div class="flex items-center justify-between gap-2">
+                    <span class="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Altimeter</span>
+                    <input class="num-mono text-right bg-blue-50 border border-blue-300 rounded px-2 py-1 w-24 text-sm" value="30.10">
+                  </div>
+                  <div class="border-t border-dashed border-slate-200 -mx-4"></div>
+                  <div class="flex items-center justify-between gap-2">
+                    <span class="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Field elev</span>
+                    <span class="num-mono text-sm text-slate-900">4,457 ft</span>
+                  </div>
+                  <div class="flex items-center justify-between gap-2">
+                    <span class="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Runway</span>
+                    <select class="num-mono text-right bg-white border border-slate-300 rounded px-2 py-1 text-sm">
+                      <option>17/35 · 5,861 ft</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+
+            </div>
+          </div>
+
+          <div>
+            <h3 class="text-xs font-semibold uppercase tracking-wider text-slate-500 mb-3">Advisories</h3>
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-2 text-sm">
+              <label class="flex items-center gap-2"><input type="checkbox" checked class="rounded"> AIRMET Tango (turbulence)</label>
+              <label class="flex items-center gap-2"><input type="checkbox" class="rounded"> Ceiling / Vis &lt; 10sm/2000′</label>
+              <label class="flex items-center gap-2"><input type="checkbox" checked class="rounded"> AIRMET Sierra (mtn obscuration)</label>
+            </div>
+          </div>
+
+        </div>
+      </article>
+    </section>
+
+    <!-- STEP 3 ─────────────────────────────────────────────── -->
+    <section id="step-3" class="relative pl-14 md:pl-16">
+      <div class="absolute left-0 top-0 bottom-0 flex flex-col items-center" aria-hidden="true">
+        <div class="num-mono flex h-10 w-10 items-center justify-center rounded-full bg-amber-500 text-white font-bold text-base shadow ring-4 ring-slate-100">3</div>
+      </div>
+      <article class="rounded-xl border border-slate-200 bg-white shadow-sm overflow-hidden">
+        <header class="flex items-start justify-between gap-4 border-b border-slate-200 px-5 py-4">
+          <div>
+            <h2 class="text-xl font-bold tracking-tight">Decision</h2>
+            <p class="text-sm text-slate-500 mt-0.5">Go / no-go summary, with detailed calculations below</p>
+          </div>
+          <span class="shrink-0 inline-flex items-center gap-1.5 rounded-full bg-amber-50 text-amber-700 border border-amber-200 px-2.5 py-1 text-xs font-medium">
+            <span class="h-1.5 w-1.5 rounded-full bg-amber-500"></span>
+            1 warning
+          </span>
+        </header>
+        <div class="px-5 py-5 space-y-4">
+
+          <div class="rounded-lg border-2 border-dashed border-slate-300 bg-slate-50 p-4 text-sm text-slate-600 italic">
+            Placeholder — this is where the <strong class="not-italic font-semibold">Go / No-Go summary panel</strong> (recommendation #1) would live: traffic-light bands for runway margin, density altitude, climb performance, weather advisories, and quals.
+          </div>
+
+          <!-- For-reference-only disclaimer ─ pulled from operational notes -->
+          <div class="rounded-lg border border-amber-200 bg-amber-50/70 px-4 py-3 flex items-start gap-2.5">
+            <svg class="h-4 w-4 text-amber-600 mt-0.5 shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z"/></svg>
+            <div class="flex-1 text-sm text-amber-900 leading-snug">
+              <strong class="font-semibold">For reference only.</strong>
+              It is up to the PIC and FRO to responsibly evaluate risks prior to release or departure. If risks cannot be reduced to an acceptable level, a no-go decision should be considered.
+              <a href="#" data-overlay-toggle="instructions" class="block mt-1 text-xs text-amber-700 hover:text-amber-900 hover:underline">Read all operational notes →</a>
+            </div>
+          </div>
+
+          <details class="rounded-lg border border-slate-200 bg-white">
+            <summary class="cursor-pointer select-none px-4 py-3 text-sm font-medium text-slate-700 flex items-center justify-between">
+              Detailed calculations
+              <span class="text-xs text-slate-400 font-normal">Density altitude · Climb · TOLD · Maneuvering</span>
+            </summary>
+            <div class="px-4 pb-4 text-sm text-slate-500">
+              The existing <code class="text-xs bg-slate-100 px-1 py-0.5 rounded">Altitudes</code>, <code class="text-xs bg-slate-100 px-1 py-0.5 rounded">ClimbPerformance</code>, <code class="text-xs bg-slate-100 px-1 py-0.5 rounded">TakeoffPerformance</code>, and <code class="text-xs bg-slate-100 px-1 py-0.5 rounded">ManeuveringPerformance</code> tables go here, unchanged.
+            </div>
+          </details>
+
+        </div>
+      </article>
+    </section>
+
+  </main>
+
+  <footer class="w-full py-6 px-4 text-center text-sm text-slate-500 border-t border-slate-200 mt-8">
+    Mockup — Mountain Worksheet numbered step shell
+  </footer>
+
+  <!-- ── Slide-over backdrop ──────────────────────────────────────────────── -->
+  <div class="slideover-backdrop" data-overlay-close></div>
+
+  <!-- ── Instructions & Operational Notes ─────────────────────────────────── -->
+  <aside class="slideover" data-name="instructions" role="dialog" aria-labelledby="instructions-title" aria-hidden="true">
+    <header class="slideover-header">
+      <h2 id="instructions-title" class="text-base font-semibold text-slate-900">Instructions &amp; Operational Notes</h2>
+      <button class="text-slate-500 hover:text-slate-900 rounded p-1" data-overlay-close aria-label="Close">
+        <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+      </button>
+    </header>
+    <div class="slideover-body">
+      <p>
+        Add sortie information in Step 1. Once that area is filled in, click the
+        <strong>Fetch weather</strong> button and the worksheet will fetch weather information from
+        <a href="https://aviationweather.gov/" target="_blank" rel="noopener noreferrer">AviationWeather.gov</a>
+        to fill out the weather and performance sections of the worksheet.
+      </p>
+
+      <h3>Special Inputs</h3>
+      <p><strong>Departure / Arrival airports:</strong> Enter the 4-letter ICAO code (e.g. KDEN) and the worksheet will populate the weather and runway information when clicking <strong>Fetch weather</strong>.</p>
+      <p><strong>Area of Operations:</strong> Enter latitude/longitude coordinates in decimal degrees DD.dddd format. You can also use other ways to indicate the area of operations — see the table below.</p>
+      <div class="overflow-x-auto">
+        <table class="min-w-full text-xs border-collapse mt-2 mb-3">
+          <thead>
+            <tr class="bg-slate-100 text-left">
+              <th class="border border-slate-300 px-2 py-1 font-semibold">Format</th>
+              <th class="border border-slate-300 px-2 py-1 font-semibold">How It Is Entered</th>
+              <th class="border border-slate-300 px-2 py-1 font-semibold">Equivalent Lat/Long</th>
+              <th class="border border-slate-300 px-2 py-1 font-semibold">Converted Decimal Format</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td class="border border-slate-300 px-2 py-1">DD.dd (with letters)</td><td class="border border-slate-300 px-2 py-1 num-mono whitespace-nowrap">36.01N/75.50W</td><td class="border border-slate-300 px-2 py-1 whitespace-nowrap">36°00'36"N / 75°30'00"W</td><td class="border border-slate-300 px-2 py-1 num-mono whitespace-nowrap">36.01/-75.50</td></tr>
+            <tr><td class="border border-slate-300 px-2 py-1">DD.dd (with a minus)</td><td class="border border-slate-300 px-2 py-1 num-mono whitespace-nowrap">36.01/-75.50</td><td class="border border-slate-300 px-2 py-1 whitespace-nowrap">36°00'36"N / 75°30'00"W</td><td class="border border-slate-300 px-2 py-1 num-mono whitespace-nowrap">36.01/-75.50</td></tr>
+            <tr><td class="border border-slate-300 px-2 py-1">DD°MM'SS" (with letters)</td><td class="border border-slate-300 px-2 py-1 num-mono whitespace-nowrap">360051N/0753004W</td><td class="border border-slate-300 px-2 py-1 whitespace-nowrap">36°00'51"N / 75°30'04"W</td><td class="border border-slate-300 px-2 py-1 num-mono whitespace-nowrap">36.01/-75.50</td></tr>
+            <tr><td class="border border-slate-300 px-2 py-1">DD°MM'SS" (with a minus)</td><td class="border border-slate-300 px-2 py-1 num-mono whitespace-nowrap">360051/-0753004</td><td class="border border-slate-300 px-2 py-1 whitespace-nowrap">36°00'51"N / 75°30'04"W</td><td class="border border-slate-300 px-2 py-1 num-mono whitespace-nowrap">36.01/-75.50</td></tr>
+            <tr><td class="border border-slate-300 px-2 py-1">DD°MM.mm (with letters)</td><td class="border border-slate-300 px-2 py-1 num-mono whitespace-nowrap">3600.86N/07530.07W</td><td class="border border-slate-300 px-2 py-1 whitespace-nowrap">36°00.86'N / 75°30.07'W</td><td class="border border-slate-300 px-2 py-1 num-mono whitespace-nowrap">36.01/-75.50</td></tr>
+            <tr><td class="border border-slate-300 px-2 py-1">DD°MM.mm (with a minus)</td><td class="border border-slate-300 px-2 py-1 num-mono whitespace-nowrap">3600.86/-07530.07</td><td class="border border-slate-300 px-2 py-1 whitespace-nowrap">36°00.86'N / 75°30.07'W</td><td class="border border-slate-300 px-2 py-1 num-mono whitespace-nowrap">36.01/-75.50</td></tr>
+            <tr><td class="border border-slate-300 px-2 py-1">Airport ID / Radial / Distance</td><td class="border border-slate-300 px-2 py-1 num-mono whitespace-nowrap">KOGD/285/34</td><td class="border border-slate-300 px-2 py-1 whitespace-nowrap">41°25'48"N / 112°42'00"W</td><td class="border border-slate-300 px-2 py-1 num-mono whitespace-nowrap">41.43/-112.70</td></tr>
+            <tr><td class="border border-slate-300 px-2 py-1">VOR ID / Radial / Distance</td><td class="border border-slate-300 px-2 py-1 num-mono whitespace-nowrap">OGD/285/34</td><td class="border border-slate-300 px-2 py-1 whitespace-nowrap">41°30'00"N / 112°45'36"W</td><td class="border border-slate-300 px-2 py-1 num-mono whitespace-nowrap">41.50/-112.76</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h3>Using the Tool</h3>
+      <ul>
+        <li>All times are entered in UTC. The local-time conversion shows below the time selector.</li>
+        <li>Sortie date and time drive the weather lookup — departure and arrival METAR/TAF are matched to your sortie time, not the current time.</li>
+        <li>Use Copy Link to save or share the worksheet — the URL captures the worksheet inputs and fetched weather/performance values. UI preferences such as the °C/°F unit are stored locally in your browser and are not shared via the link.</li>
+        <li>Reset Worksheet clears the worksheet inputs from the URL and reloads with defaults — the date and time reset to the next top-of-hour in UTC, and the °C/°F preference is preserved. Copy the link first if you want to keep the current state.</li>
+        <li>Toggle °C/°F at any time using the temperature unit button in the header. The setting is saved locally in your browser so it persists across sessions on the same device.</li>
+        <li>Operating Altitude drives the in-flight density-altitude and maneuvering-speed calculations. Set it to the planned altitude you'll be operating at over the area.</li>
+        <li>Review the Mountain Flying Checklist (Checklist button in the action bar) before flight in addition to the worksheet values.</li>
+      </ul>
+
+      <h3>Operational Notes</h3>
+      <ul>
+        <li><strong>This tool is for reference purposes only.</strong> It is up to the PIC and FRO to responsibly evaluate risks prior to release or departure. If risks cannot be reduced to an acceptable level, a no-go decision should be considered.</li>
+        <li>Warnings are highlighted in red/yellow, but the worksheet does not cover all the risks involved.</li>
+        <li>Complete and upload this document to "Sortie Files" for a mountain flight.</li>
+        <li>If computations reveal that a particular performance item is marginal, consult the POH prior to flight.</li>
+        <li>C206: 16,000' altitude limit is based on aircraft operations below critical altitude. See POH for operations above this altitude.</li>
+        <li>Some performance values may vary slightly from the POH for temperatures, altitudes, and weights.</li>
+        <li>Rate of Climb (ROC) for actual weights is an estimate only. ROC at Max Gross Weights (MGW) are from the POH. Therefore, actual ROC and MGW ROC values may not match. If actual weight results are unexpected, use MGW or POH values. Remember, POH values are for a new aircraft with a test pilot. Your actual climb rates can, and probably will be, lower. ROC rates that are significantly lower than POH values may justify a Return to Base decision.</li>
+        <li>Performance is computed from POH tables but may not be accurate outside the table range.</li>
+        <li>A current CAPF 70-5 Mountain Flight Endorsement or qualified instructor is required to takeoff/land in airports located in mountainous terrain.</li>
+        <li>A current Mountain Flying Certification SQTR and CAPF 70-91, Section V signoff, or qualified instructor is required to fly mountain search.</li>
+        <li>Density altitude calculation uses a dry air approximation.</li>
+      </ul>
+    </div>
+  </aside>
+
+  <!-- ── Mountain Flying Checklist ────────────────────────────────────────── -->
+  <aside class="slideover" data-name="checklist" role="dialog" aria-labelledby="checklist-title" aria-hidden="true">
+    <header class="slideover-header">
+      <h2 id="checklist-title" class="text-base font-semibold text-slate-900">Mountain Flying Checklist</h2>
+      <button class="text-slate-500 hover:text-slate-900 rounded p-1" data-overlay-close aria-label="Close">
+        <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+      </button>
+    </header>
+    <div class="slideover-body">
+      <h3>Basic Preflight</h3>
+      <ul>
+        <li>Ensure attire, safety, oxygen, and survival equipment are appropriate for the flight</li>
+        <li>Ensure adequate fuel reserves exist for mountain flight.</li>
+        <li>File flight plan, if necessary</li>
+        <li>Conduct a good aircraft preflight</li>
+        <li>Ensure inoperative equipment and discrepancies are appropriate for mountain flight</li>
+        <li>Discuss crew responsibilities, Crew Resource Management and mission briefing</li>
+      </ul>
+
+      <h3>Weather Preflight</h3>
+      <ul>
+        <li>Verify all weather, especially winds and turbulence, remains within release limits 2 hours prior to flight. If not, consult with the Flight Release Officer</li>
+        <li>Determine where updraft, downdraft and turbulent areas are likely to occur</li>
+        <li>Verify ceilings and visibility are much greater than marginal VFR all along route (2000'/10 SM or better is ideal). If not, consider aborting mission or consult with the Flight Release Officer</li>
+      </ul>
+
+      <h3>Weight and Balance Preflight</h3>
+      <ul>
+        <li>Ensure weight and balance within limits for actual loading; weight from ForeFlight or POH</li>
+        <li>Attempt to maintain weight less than 90% of Maximum Gross Weight for mountain flight</li>
+      </ul>
+
+      <h3>Aircraft Performance Preflight</h3>
+      <ul>
+        <li>Verify Rate of Climb is greater than 300 feet/minute all along route and in area of operations. If not, consider aborting mission or consult with the Flight Release Officer</li>
+        <li>Verify Take Off plus Landing Ground Roll is less than Runway length. If not, consider aborting mission or consult with the Flight Release Officer</li>
+      </ul>
+
+      <h3>Departure</h3>
+      <ul>
+        <li>Define runway abort point (75% of indicated takeoff airspeed at runway midpoint)</li>
+        <li>Mixture set for max power or POH</li>
+        <li>Execute short field take off techniques to clear actual or simulated obstacles</li>
+      </ul>
+
+      <h3>Enroute</h3>
+      <ul>
+        <li>Remain at or above 2000 feet AGL unless descending to land if MFE qualified (Note 13)</li>
+        <li>Remain at or above 1000 feet AGL unless descending to land or conducting a mission as a Mountain qualified Mission Pilot (Note 14)</li>
+      </ul>
+
+      <h3>Arrival</h3>
+      <ul>
+        <li>Verify 300 feet/minute Rate of Climb possible. If not, divert.</li>
+        <li>Verify go around possible at airport. If not, divert.</li>
+        <li>Set runway go around point to stop safely</li>
+        <li>Mixture set for max power or POH</li>
+        <li>Use short field landing techniques</li>
+      </ul>
+    </div>
+  </aside>
+
+  <!-- ── Demo state cycler (mockup affordance only — not in production) ───── -->
+  <div class="demo-chip" aria-label="Mockup state cycler">
+    <span class="text-slate-400 text-[10px] uppercase tracking-wider">Demo</span>
+    <button id="demo-prev" title="Previous state">←</button>
+    <span class="demo-state-label" id="demo-state-label">ready</span>
+    <button id="demo-next" title="Next state">→</button>
+  </div>
+
+  <script>
+    // Highlight whichever step is currently in view in the sticky nav.
+    const links = document.querySelectorAll('.step-link');
+    const setActive = (id) => {
+      links.forEach((l) => {
+        const active = l.getAttribute('href') === `#${id}`;
+        l.classList.toggle('ring-2', active);
+        l.classList.toggle('ring-slate-900', active);
+        l.classList.toggle('shadow-sm', active);
+      });
+    };
+    setActive('step-1');
+    const observer = new IntersectionObserver((entries) => {
+      entries
+        .filter((e) => e.isIntersecting)
+        .sort((a, b) => a.target.getBoundingClientRect().top - b.target.getBoundingClientRect().top)
+        .forEach((e) => setActive(e.target.id));
+    }, { rootMargin: '-30% 0px -60% 0px', threshold: 0 });
+    document.querySelectorAll('section[id^="step-"]').forEach((s) => observer.observe(s));
+
+    // Action-bar state cycler — demo affordance to show all 4 states.
+    const states = ['incomplete', 'ready', 'fetched', 'all-done'];
+    const label = document.getElementById('demo-state-label');
+    const setState = (s) => {
+      document.body.dataset.state = s;
+      label.textContent = s;
+    };
+    document.getElementById('demo-prev').addEventListener('click', () => {
+      const i = states.indexOf(document.body.dataset.state);
+      setState(states[(i - 1 + states.length) % states.length]);
+    });
+    document.getElementById('demo-next').addEventListener('click', () => {
+      const i = states.indexOf(document.body.dataset.state);
+      setState(states[(i + 1) % states.length]);
+    });
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'ArrowLeft')  document.getElementById('demo-prev').click();
+      if (e.key === 'ArrowRight') document.getElementById('demo-next').click();
+    });
+
+    // Slide-over (Instructions, Checklist) — toggle / swap / close.
+    const setOverlay = (name) => {
+      document.body.dataset.overlay = name || "";
+      document.querySelectorAll('.slideover').forEach((s) => {
+        s.setAttribute('aria-hidden', s.dataset.name === name ? 'false' : 'true');
+      });
+    };
+    document.querySelectorAll('[data-overlay-toggle]').forEach((el) => {
+      el.addEventListener('click', (e) => {
+        e.preventDefault();
+        const target = el.dataset.overlayToggle;
+        setOverlay(document.body.dataset.overlay === target ? "" : target);
+      });
+    });
+    document.querySelectorAll('[data-overlay-close]').forEach((el) => {
+      el.addEventListener('click', () => setOverlay(""));
+    });
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && document.body.dataset.overlay) setOverlay("");
+    });
+  </script>
+</body>
+</html>

--- a/docs/superpowers/plans/2026-05-11-worksheet-ui-1-step-shell.md
+++ b/docs/superpowers/plans/2026-05-11-worksheet-ui-1-step-shell.md
@@ -1,0 +1,451 @@
+# Worksheet UI Redesign — Phase 1: Step Shell Foundation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Introduce a sticky 3-pill stepper above the worksheet that scroll-spies the three logical sections (Sortie Details, Weather, Decision), and relocate `InstructionsAndNotes` from the top of the page to the bottom alongside `MountainFlyingChecklist`. No inner-component refactors — this phase is purely navigational.
+
+**Architecture:** One new client component (`Stepper`) using `IntersectionObserver` for scroll-spy. `AppInputs` is reshaped so its rendered children fall under two semantic `<section>` elements with `id` anchors; `AppContainer` wraps `Calculations` in a third anchor. Heroicons used for the separator caret. No state changes — step colors are hardcoded in this phase (Phase 3 will derive them from real data).
+
+**Tech Stack:** Next.js 16 App Router, React 19, Tailwind v4, `@heroicons/react/24/outline`, Jest + Testing Library (existing setup).
+
+**Read before starting:** `docs/superpowers/plans/2026-05-11-worksheet-ui-redesign-index.md` for the full series context, and skim `docs/numbered-step-shell-mockup.html` for the visual target.
+
+---
+
+## File Structure
+
+**Create:**
+- `src/components/Stepper.tsx` — sticky 3-pill nav with `IntersectionObserver` scroll-spy
+- `src/components/Stepper.test.tsx` — colocated component test
+
+**Modify:**
+- `src/components/AppContainer.tsx` — render `<Stepper>` below header; wrap `<Calculations>` in `<section id="step-decision">`; move `<InstructionsAndNotes>` from above `<AppInputs>` to below `<MountainFlyingChecklist>`
+- `src/components/AppInputs.tsx` — replace the single outer flex `<div>` with two semantic `<section>` elements: `id="step-sortie"` (wraps `SortieInfo` + `MountainQuals`) and `id="step-weather"` (wraps `WeatherInfo` + `AircraftPerformance`)
+- `src/components/AppContainer.test.tsx` — assert new order; assert stepper is present
+- `src/components/AppInputs.test.tsx` — assert the two section anchors exist
+
+**Anchor ids used (kept consistent across all 5 phases):**
+- `step-sortie` (Step 1, slate / active)
+- `step-weather` (Step 2, emerald / complete once fetched)
+- `step-decision` (Step 3, amber / warning when verdict has cautions)
+
+---
+
+## Task 1: Stepper component — skeleton + render test
+
+**Files:**
+- Create: `src/components/Stepper.tsx`
+- Create: `src/components/Stepper.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// src/components/Stepper.test.tsx
+import { render, screen } from "@testing-library/react";
+import Stepper from "./Stepper";
+
+const defaultSteps = [
+  { id: "step-sortie",   number: 1, label: "Sortie Details", status: "active"   as const },
+  { id: "step-weather",  number: 2, label: "Weather",        status: "pending"  as const },
+  { id: "step-decision", number: 3, label: "Decision",       status: "pending"  as const },
+];
+
+describe("Stepper", () => {
+  it("renders all step labels and numbers", () => {
+    render(<Stepper steps={defaultSteps} />);
+    expect(screen.getByText("Sortie Details")).toBeInTheDocument();
+    expect(screen.getByText("Weather")).toBeInTheDocument();
+    expect(screen.getByText("Decision")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("renders each step as an anchor pointing to its section id", () => {
+    render(<Stepper steps={defaultSteps} />);
+    expect(screen.getByRole("link", { name: /Sortie Details/ })).toHaveAttribute("href", "#step-sortie");
+    expect(screen.getByRole("link", { name: /Weather/ })).toHaveAttribute("href", "#step-weather");
+    expect(screen.getByRole("link", { name: /Decision/ })).toHaveAttribute("href", "#step-decision");
+  });
+
+  it("uses the active-step className when activeId is explicitly set", () => {
+    render(<Stepper steps={defaultSteps} activeId="step-weather" />);
+    const weather = screen.getByRole("link", { name: /Weather/ });
+    expect(weather).toHaveAttribute("data-active", "true");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest src/components/Stepper.test.tsx`
+Expected: FAIL — `Cannot find module './Stepper'`.
+
+- [ ] **Step 3: Implement the component**
+
+```tsx
+// src/components/Stepper.tsx
+"use client";
+
+import { Fragment, useEffect, useState } from "react";
+import { ChevronRightIcon } from "@heroicons/react/24/outline";
+
+export type StepStatus = "pending" | "active" | "complete" | "warning";
+
+export interface StepperStep {
+  id: string;
+  number: number;
+  label: string;
+  status: StepStatus;
+  /** Optional small badge text rendered after the label (e.g. "8 of 11", "●", "⚠ 1"). */
+  badge?: string;
+}
+
+interface StepperProps {
+  steps: StepperStep[];
+  /** If set, this id is the active pill. If undefined, scroll-spy picks the active id. */
+  activeId?: string;
+}
+
+const circleBg: Record<StepStatus, string> = {
+  pending:  "bg-slate-300",
+  active:   "bg-slate-900",
+  complete: "bg-emerald-500",
+  warning:  "bg-amber-500",
+};
+
+const badgeColor: Record<StepStatus, string> = {
+  pending:  "text-slate-500",
+  active:   "text-slate-900",
+  complete: "text-emerald-600",
+  warning:  "text-amber-600",
+};
+
+export default function Stepper({ steps, activeId }: StepperProps) {
+  const [scrollSpyId, setScrollSpyId] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (activeId !== undefined) return; // explicit control wins
+    if (typeof IntersectionObserver === "undefined") return; // SSR / jsdom safety
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries.filter((e) => e.isIntersecting);
+        if (visible.length === 0) return;
+        const topMost = visible.sort(
+          (a, b) =>
+            a.target.getBoundingClientRect().top -
+            b.target.getBoundingClientRect().top
+        )[0];
+        setScrollSpyId(topMost.target.id);
+      },
+      { rootMargin: "-30% 0px -60% 0px", threshold: 0 }
+    );
+    steps.forEach((step) => {
+      const el = document.getElementById(step.id);
+      if (el) observer.observe(el);
+    });
+    return () => observer.disconnect();
+  }, [steps, activeId]);
+
+  const currentId = activeId ?? scrollSpyId ?? steps[0]?.id;
+
+  return (
+    <nav
+      aria-label="Worksheet steps"
+      className="sticky top-0 z-20 border-b border-slate-200 bg-slate-50/95 backdrop-blur supports-[backdrop-filter]:bg-slate-50/75"
+    >
+      <div className="mx-auto max-w-5xl px-4 py-2.5 md:px-6">
+        <ol className="flex items-center gap-1.5 overflow-x-auto text-sm">
+          {steps.map((step, i) => {
+            const isActive = currentId === step.id;
+            return (
+              <Fragment key={step.id}>
+                {i > 0 && (
+                  <li aria-hidden="true" className="text-slate-300">
+                    <ChevronRightIcon className="h-3.5 w-3.5" />
+                  </li>
+                )}
+                <li className="shrink-0">
+                  <a
+                    href={`#${step.id}`}
+                    data-active={isActive || undefined}
+                    className="flex items-center gap-2 rounded-full bg-white px-3 py-1.5 transition-all data-[active]:ring-2 data-[active]:ring-slate-900 data-[active]:shadow-sm"
+                  >
+                    <span
+                      className={`flex h-6 w-6 items-center justify-center rounded-full ${circleBg[step.status]} font-mono text-xs font-semibold text-white`}
+                    >
+                      {step.number}
+                    </span>
+                    <span
+                      className={
+                        isActive
+                          ? "font-medium text-slate-900"
+                          : "text-slate-700"
+                      }
+                    >
+                      {step.label}
+                    </span>
+                    {step.badge && (
+                      <span
+                        className={`text-xs font-medium ${badgeColor[step.status]}`}
+                      >
+                        {step.badge}
+                      </span>
+                    )}
+                  </a>
+                </li>
+              </Fragment>
+            );
+          })}
+        </ol>
+      </div>
+    </nav>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx jest src/components/Stepper.test.tsx`
+Expected: PASS — all three tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/Stepper.tsx src/components/Stepper.test.tsx
+git commit -m "Add Stepper component for worksheet UI redesign
+
+Sticky 3-pill nav with IntersectionObserver-based scroll-spy. Per-step
+status (pending/active/complete/warning) drives the numbered-circle
+color. Caller can override scroll-spy via the activeId prop."
+```
+
+---
+
+## Task 2: Add anchor ids to AppInputs sections
+
+**Files:**
+- Modify: `src/components/AppInputs.tsx` (whole render block, lines 27–44)
+- Modify: `src/components/AppInputs.test.tsx` (add anchor assertion)
+
+- [ ] **Step 1: Update the test to assert the anchors exist**
+
+Open `src/components/AppInputs.test.tsx` and add this test inside the existing `describe` block:
+
+```tsx
+it("wraps Sortie Details and Weather in semantic sections with stable anchor ids", () => {
+  const { container } = render(
+    <AppInputs state={defaultState} onStateUpdate={() => {}} />
+  );
+  expect(container.querySelector("#step-sortie")).not.toBeNull();
+  expect(container.querySelector("#step-weather")).not.toBeNull();
+});
+```
+
+(If `defaultState` doesn't already exist in the test file, mirror the literal from `AppContainer.tsx:36-78` or import the existing fixture used by other tests in that file.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest src/components/AppInputs.test.tsx`
+Expected: FAIL — `#step-sortie` not found.
+
+- [ ] **Step 3: Restructure the AppInputs render**
+
+Replace the JSX `return` block (currently lines 27–44 of `src/components/AppInputs.tsx`) with:
+
+```tsx
+return (
+  <div className="flex w-full max-w-4xl flex-col gap-8">
+    <section id="step-sortie" className="flex flex-col gap-8 scroll-mt-[60px]">
+      <SortieInfo onUpdate={handleUpdate} initialData={state} />
+      <MountainQuals onUpdate={handleUpdate} initialData={state} />
+    </section>
+    <section id="step-weather" className="flex flex-col gap-8 scroll-mt-[60px]">
+      <WeatherInfo
+        onUpdate={handleUpdate}
+        initialData={state}
+        lastUpdated={weatherLastUpdated}
+        useFahrenheit={useFahrenheit}
+      />
+      <AircraftPerformance
+        onUpdate={handleUpdate}
+        initialData={state}
+        worksheetData={state}
+        useFahrenheit={useFahrenheit}
+      />
+    </section>
+  </div>
+);
+```
+
+`scroll-mt-[60px]` accounts for the ~44px-tall sticky stepper plus padding so anchor jumps don't hide section headers under it. (Phase 3 increases this when the action bar adds a second sticky stripe.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx jest src/components/AppInputs.test.tsx`
+Expected: PASS — anchor assertion green, no other AppInputs tests broken.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/AppInputs.tsx src/components/AppInputs.test.tsx
+git commit -m "Wrap AppInputs children in step-sortie and step-weather sections
+
+Adds stable anchor ids used by the new Stepper. No visual change beyond
+the wrapping <section> element."
+```
+
+---
+
+## Task 3: Wrap Calculations in step-decision anchor + integrate Stepper + relocate InstructionsAndNotes
+
+**Files:**
+- Modify: `src/components/AppContainer.tsx` (the JSX `return`, lines 114–151)
+- Modify: `src/components/AppContainer.test.tsx`
+
+- [ ] **Step 1: Update the test**
+
+Open `src/components/AppContainer.test.tsx` and add (inside the existing top-level `describe`):
+
+```tsx
+it("renders the worksheet Stepper above the inputs", () => {
+  render(<AppContainer />);
+  expect(screen.getByRole("navigation", { name: /worksheet steps/i })).toBeInTheDocument();
+});
+
+it("wraps Calculations in the step-decision anchor", () => {
+  const { container } = render(<AppContainer />);
+  const anchor = container.querySelector("#step-decision");
+  expect(anchor).not.toBeNull();
+});
+
+it("renders InstructionsAndNotes below MountainFlyingChecklist", () => {
+  const { container } = render(<AppContainer />);
+  const all = Array.from(container.querySelectorAll("details > summary"));
+  const labels = all.map((s) => s.textContent ?? "");
+  const checklistIdx = labels.findIndex((t) => t.includes("Mountain Flying Checklist"));
+  const instructionsIdx = labels.findIndex((t) => t.includes("Instructions and Notes"));
+  expect(checklistIdx).toBeGreaterThan(-1);
+  expect(instructionsIdx).toBeGreaterThan(-1);
+  expect(instructionsIdx).toBeGreaterThan(checklistIdx);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest src/components/AppContainer.test.tsx`
+Expected: FAIL — `navigation` not found; `#step-decision` not found; InstructionsAndNotes still above.
+
+- [ ] **Step 3: Update the AppContainer imports**
+
+At the top of `src/components/AppContainer.tsx`, add:
+
+```tsx
+import Stepper from "@/components/Stepper";
+```
+
+- [ ] **Step 4: Replace the `<main>` block**
+
+Replace the existing `<main>...</main>` (currently lines 126–138) with:
+
+```tsx
+<Stepper
+  steps={[
+    { id: "step-sortie",   number: 1, label: "Sortie Details", status: "active" },
+    { id: "step-weather",  number: 2, label: "Weather",        status: "pending" },
+    { id: "step-decision", number: 3, label: "Decision",       status: "pending" },
+  ]}
+/>
+<main className="flex-1 w-full flex justify-center px-2 md:px-8 pb-20">
+  <div className="w-full max-w-5xl flex flex-col gap-16 items-center">
+    <AppInputs
+      state={state}
+      onStateUpdate={handleUpdate}
+      weatherLastUpdated={weatherLastUpdated ?? undefined}
+      useFahrenheit={useFahrenheit}
+    />
+    <section id="step-decision" className="w-full flex justify-center scroll-mt-[60px]">
+      <Calculations state={state} />
+    </section>
+    <MountainFlyingChecklist />
+    <InstructionsAndNotes />
+  </div>
+</main>
+```
+
+(Step statuses are hardcoded here. Phase 3 wires them to derived state.)
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npx jest src/components/AppContainer.test.tsx`
+Expected: PASS — Stepper nav present, `#step-decision` present, InstructionsAndNotes ordered after the Checklist.
+
+- [ ] **Step 6: Run the full test suite to catch regressions**
+
+Run: `npx jest`
+Expected: PASS — no other tests broken. If `AppContainer.test.tsx` had a snapshot assertion, update it (`-u`) once you've eyeballed that the new structure is what you want.
+
+- [ ] **Step 7: Visual smoke test**
+
+```bash
+npm run dev
+```
+
+Open <http://localhost:3000>. Verify by eye:
+
+1. A sticky bar with three pills (Sortie Details / Weather / Decision) appears below the dark header.
+2. Clicking each pill scrolls to the right section and that section's heading is visible (not hidden under the stepper).
+3. As you scroll, the active pill (with the slate ring around it) tracks the section in view.
+4. `Instructions and Notes` now lives at the bottom of the page, after `Mountain Flying Checklist`.
+
+If any of those fail, fix and re-run `npx jest`. Don't commit until visual smoke passes.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/components/AppContainer.tsx src/components/AppContainer.test.tsx
+git commit -m "Wire Stepper into AppContainer and relocate Instructions
+
+- Renders Stepper below the worksheet header with three hardcoded
+  steps (real status derivation comes in phase 3).
+- Wraps Calculations in #step-decision anchor for stepper navigation.
+- Moves InstructionsAndNotes from the top of main to the bottom,
+  alongside MountainFlyingChecklist."
+```
+
+---
+
+## Verification — full phase
+
+- [ ] All four commits are on the branch:
+  ```bash
+  git log --oneline -4
+  ```
+  Expected: the three commits from tasks 1–3 plus the existing tip.
+
+- [ ] Jest is green:
+  ```bash
+  npx jest
+  ```
+
+- [ ] TypeScript is clean:
+  ```bash
+  npx tsc --noEmit
+  ```
+
+- [ ] Manual checklist (in a browser):
+  - Stepper sticks to the top of the viewport on scroll
+  - Each pill's anchor link scrolls to the right section with a comfortable offset
+  - Scroll-spy highlights the pill matching the section currently in view
+  - Mountain Flying Checklist and Instructions and Notes both render at the bottom, in that order, both still collapsible
+  - No console errors
+
+---
+
+## Out of scope for Phase 1 (do **not** add here)
+
+- `StepShell` component (numbered circle + left rail + section card) — Phase 2
+- Slim header / Fetch button relocation — Phase 3
+- Weather section merge / airport cards — Phase 4
+- Slide-overs for Instructions and Checklist — Phase 5
+- Real step status derivation from state — Phase 3

--- a/docs/superpowers/plans/2026-05-11-worksheet-ui-redesign-index.md
+++ b/docs/superpowers/plans/2026-05-11-worksheet-ui-redesign-index.md
@@ -28,7 +28,7 @@ This redesign turns the Mountain Worksheet from a long stack of equal-weight sec
 | Component | Phase | Responsibility |
 |---|---|---|
 | `Stepper` | 1 | Sticky 3-pill nav with scroll-spy |
-| `StepShell` | 1 | Numbered card wrapper with left-rail spine and header chip |
+| `StepShell` | 2 | Numbered card wrapper with left-rail spine and header chip |
 | `ActionBar` | 3 | Sticky state-aware action bar driven by a derived state machine |
 | `SlideOver` | 5 | Generic right-side panel built on `@headlessui/react` `Dialog` |
 | `AirportCard` | 4 | One-airport card with METAR-driven + reference fields |

--- a/docs/superpowers/plans/2026-05-11-worksheet-ui-redesign-index.md
+++ b/docs/superpowers/plans/2026-05-11-worksheet-ui-redesign-index.md
@@ -1,0 +1,50 @@
+# Worksheet UI Redesign — Master Index
+
+**Source:** `docs/numbered-step-shell-mockup.html` (validated 2026-05-10), `docs/ux-assessment.md`
+
+This redesign turns the Mountain Worksheet from a long stack of equal-weight sections into a guided 3-step flow with a sticky stepper and state-aware action bar. The work is broken into **5 sequenced plans**, each shipping as its own PR. Run them in order — each builds on the structure the previous one established.
+
+## Plans in this series
+
+| Phase | Plan file | What ships |
+|---|---|---|
+| 1 | `2026-05-11-worksheet-ui-1-step-shell.md` | Sticky 3-pill stepper above existing content with scroll-spy; existing sections gain `id` anchors; `InstructionsAndNotes` moves from page-top to page-bottom alongside `MountainFlyingChecklist` |
+| 2 | `2026-05-11-worksheet-ui-2-step-cards.md` | New `StepShell` component (numbered circle + left-rail spine + section card); existing sections refactored to drop their outer cards and render inside `StepShell`; Sortie Details sub-headings (Pilot & Aircraft / When / Where / Pilot Qualifications); duplicate Operating Altitude removed |
+| 3 | `2026-05-11-worksheet-ui-3-action-bar.md` | Slim header (Reset / Copy link / °F only); sticky state-aware action bar with morphing button (incomplete / ready / fetched / all-done); Fetch Weather migrates from header to action bar |
+| 4 | `2026-05-11-worksheet-ui-4-weather-merge.md` | Weather and Aircraft Performance merge into one Step 2 with three subgroups (Aloft / At airports / Advisories); airport-card layout; runway dropdown defaulting to shortest |
+| 5 | `2026-05-11-worksheet-ui-5-slideovers-print.md` | Decision section with "For reference only" inline disclaimer; Instructions and Checklist convert from bottom accordions to slide-over panels (`?` icon in header, "Checklist" button in action bar); `@media print` stylesheet for the Sortie Files PDF artifact |
+
+## Out of scope (separate plans)
+
+- **Go / No-Go panel** (assessment rec #1) — the highest-leverage info-architecture work, but distinct from the layout shell. Mocked in `docs/decision-panel-mockup.html`. A future plan will design and implement the panel; this index covers only what's in `numbered-step-shell-mockup.html`.
+- **Soften Reset button** (rec #7), **Quals echoed downstream** (rec #8), **AIRMET flag echoes** (rec #9), **Mobile responsiveness for tables** (rec #12) — small polish items, batched as a follow-up plan.
+
+## Architectural decisions shared across phases
+
+**State** stays lifted in `AppContainer.tsx` via the existing `useUrlState` hook. No new state library. The "action bar state" (Phase 3) is a *derived* value computed from the existing state pieces, not a new state.
+
+**New shared components** introduced across phases:
+
+| Component | Phase | Responsibility |
+|---|---|---|
+| `Stepper` | 1 | Sticky 3-pill nav with scroll-spy |
+| `StepShell` | 1 | Numbered card wrapper with left-rail spine and header chip |
+| `ActionBar` | 3 | Sticky state-aware action bar driven by a derived state machine |
+| `SlideOver` | 5 | Generic right-side panel built on `@headlessui/react` `Dialog` |
+| `AirportCard` | 4 | One-airport card with METAR-driven + reference fields |
+
+**Styling**: Tailwind v4 is already configured via `@import "tailwindcss"` in `src/app/globals.css`. The mockup uses only Tailwind utility classes — port them directly. Heroicons are already available (`@heroicons/react/24/outline`); replace inline SVGs from the mockup with Heroicons equivalents.
+
+**Testing**: TDD for component logic (state derivation, scroll-spy, slide-over toggling). Visual layout changes verified manually in `npm run dev`. Existing tests for `WorksheetHeader`, `AppContainer`, `AppInputs`, etc. are updated as needed in the phase that touches them.
+
+**Commit cadence**: each task ends in a commit. Each phase ends in a PR.
+
+## Reading order for the engineer
+
+1. Read this index.
+2. Open the mockup in a browser:
+   ```
+   open docs/numbered-step-shell-mockup.html
+   ```
+   Cycle through all four states in the bottom-right demo chip to see the action bar morph (Phase 3 outcome) — that's the target end state for the whole series.
+3. Pick up the Phase 1 plan and start there.

--- a/docs/ux-assessment.md
+++ b/docs/ux-assessment.md
@@ -1,0 +1,104 @@
+# Mountain Worksheet — UX Assessment
+
+_Reviewed 2026-05-10. Scope: usability of the existing flow, not visual redesign._
+
+## The core flow problem
+
+The page is **eight stacked sections of equal visual weight** — Instructions, Sortie Info, Quals, Weather, Aircraft Perf, Calculations, Checklist, Footer — with no sense of sequence or destination. A pilot opening this for the first time has no idea whether to start at the top, click `Fetch Weather` first, or scroll to Calculations. The actual workflow ("fill sortie info → fetch → review → decide") is documented only inside the collapsed `Instructions and Notes` section.
+
+Everything below flows from this: the tool computes great numbers, but doesn't *narrate the decision* the pilot is trying to make.
+
+---
+
+## High-impact changes (flow & decision)
+
+### 1. Add a Go/No-Go summary at the top of `Calculations`
+_File: `src/components/Calculations.tsx`_
+
+Right now the most important signals are scattered:
+
+- Density altitude is row 3 in `Altitudes` (`Altitudes.tsx:38-42`)
+- Available runway remaining (negative = bad) is row 3 in `TakeoffPerformance` (`TakeoffPerformance.tsx:272-323`)
+- AIRMET flags (turb/cielVis/mtnObsc) live on the input side, never re-surfaced
+- Climb rate vs. terrain is just a number with no context
+
+A pilot has to mentally synthesize ~10 values into "is this safe?". Surface that synthesis: a single panel with traffic-light banding for `Runway margin`, `Density altitude`, `Climb performance`, `Weather warnings`, `Quals`. Anything red = a no-go discussion. This is by far the biggest information-conveyance win.
+
+### 2. Make the Fetch Weather button explain itself
+_File: `src/components/WorksheetHeader.tsx:134-153`_
+
+The button is `disabled` when inputs are missing but says nothing about *what's missing*. Add a tooltip or sublabel: "Need departure airport and date/time first." Better: move (or duplicate) the button into the Weather section as a primary action — currently the button is at the top of the page, but the data lands further down, so users do a scroll-up → click → scroll-down dance.
+
+### 3. Sequence the page visually
+_Files: `src/components/AppContainer.tsx:126-138`, `AppInputs.tsx:27-44`_
+
+Number the sections or add a sticky "step" indicator:
+
+1. **Flight details** (sortie + quals)
+2. **Weather** (fetch + review)
+3. **Performance** (auto-filled, override as needed)
+4. **Decision** (calculations + go/no-go)
+
+Even just numbered headings ("1. Flight Details", "2. Weather") would establish intent. Today every `h2` is identical weight.
+
+See `docs/numbered-step-shell-mockup.html` for a concrete mockup of this.
+
+### 4. Group Sortie Info by concept
+_File: `src/components/SortieInfo.tsx:206-381`_
+
+11 fields in one flat 2-column grid is high cognitive load. Visible sub-groupings would help a lot:
+
+- **Pilot & Aircraft**: Pilot, AC Model, Tail #
+- **When**: Date, Time (UTC), Duration, + local-time helper
+- **Where**: Departure, Area of Ops/Route, Arrival, Operating Altitude
+- **Weight**: Takeoff Weight
+
+Also: **operating altitude is currently in two places** — Sortie Info (editable, `SortieInfo.tsx:339-350`) and Aircraft Performance (read-only `—`, `AircraftPerformance.tsx:377-381`). Pick one home; the duplicate read-only field adds noise without information.
+
+---
+
+## Medium-impact (friction reduction)
+
+### 5. Explain the blue-tinted cells
+_Files: `WeatherInfo.tsx:170-185`, `AircraftPerformance.tsx:149-181`_
+
+The API-populated styling is a great touch, but a pilot has no idea blue means "fetched from weather.gov — you can still override." Add a tiny legend once at the top of the weather/perf section: `■ Fetched from weather.gov · type to override`.
+
+### 6. Make the local-time helper actionable
+_File: `SortieInfo.tsx:144-204`_
+
+Current: `06/15/26 1300 local (UTC-7), 3 hours from now` — the operationally useful fact (*how soon*) is at the end. Flip it: lead with "**In 3 hours** — 13:00 local, Sun 15 Jun (UTC-7)". Bonus: color the relative-time chip amber if the sortie is in the past or >12 h out, since weather forecasts beyond ~12 h are coarser.
+
+### 7. Soften the Reset button
+_File: `WorksheetHeader.tsx:107-112`_
+
+Big red `Reset Worksheet` next to `Copy Link` is a misclick magnet. The action does `window.location.reload()` — irreversible. Either: (a) require confirmation, (b) make it a secondary-styled link with an "Are you sure?" inline confirm, or (c) toast an "Undo" for 10 s by stashing the prior URL.
+
+### 8. Show consequences of unchecked Quals
+_File: `MountainQuals.tsx`_
+
+The two checkboxes (`mtnEndorse`, `mtnCert`) are collected but never re-surfaced. If unchecked, callouts in the Go/No-Go panel (`Mountain Endorsement required for departure/arrival at this airport`, `SQTR required for mountain search`) make the inputs feel load-bearing instead of decorative.
+
+### 9. Surface AIRMET flags downstream
+_Files: `WeatherInfo.tsx:353-415` → `WeatherWarningsPanel.tsx`_
+
+The Turb / Ceil-Vis / Mtn-Obsc checkboxes appear as inputs but vanish from the rest of the page. Echo them in the Calculations area (or the Go/No-Go panel) with the same `WeatherWarningsPanel` styling — that panel already exists; just feed it the AIRMETs.
+
+---
+
+## Polish
+
+### 10. Lift / link the Mountain Flying Checklist
+It's last, after Calculations (`AppContainer.tsx:136`), but a pilot typically uses it *during* preflight, not after the numbers. Either move it up, or add a sticky "Checklist" jump-link in the header.
+
+### 11. Print / PDF export
+Notes say "upload this document to Sortie Files" (`InstructionsAndNotes.tsx:71`), but there's no print-optimized view. A `@media print` stylesheet + a "Print/PDF" button gives pilots a real artifact for the mission record.
+
+### 12. Mobile tables
+`WeatherInfo` and `AircraftPerformance` both rely on `overflow-x-auto` — usable but cramped. A breakpoint that stacks weather as "per-altitude cards" and aircraft perf as "per-phase cards" would be friendlier on a phone in the cockpit/FBO.
+
+---
+
+## Suggested sequencing
+
+If sequencing the work: **#1 (Go/No-Go panel) → #2 (Fetch button affordance) → #3 (numbered sections) → #4 (group Sortie Info)**. That set alone changes the tool from "a calculator with sections" into "a guided pre-flight decision aid" without any visual redesign.

--- a/src/components/AppContainer.test.tsx
+++ b/src/components/AppContainer.test.tsx
@@ -6,4 +6,26 @@ describe("AppContainer", () => {
     render(<AppContainer />);
     expect(screen.getByText("Mountain Flying Worksheet")).toBeInTheDocument();
   });
+
+  it("renders the worksheet Stepper above the inputs", () => {
+    render(<AppContainer />);
+    expect(screen.getByRole("navigation", { name: /worksheet steps/i })).toBeInTheDocument();
+  });
+
+  it("wraps Calculations in the step-decision anchor", () => {
+    const { container } = render(<AppContainer />);
+    const anchor = container.querySelector("#step-decision");
+    expect(anchor).not.toBeNull();
+  });
+
+  it("renders InstructionsAndNotes below MountainFlyingChecklist", () => {
+    const { container } = render(<AppContainer />);
+    const all = Array.from(container.querySelectorAll("details > summary"));
+    const labels = all.map((s) => s.textContent ?? "");
+    const checklistIdx = labels.findIndex((t) => t.includes("Mountain Flying Checklist"));
+    const instructionsIdx = labels.findIndex((t) => t.includes("Instructions and Notes"));
+    expect(checklistIdx).toBeGreaterThan(-1);
+    expect(instructionsIdx).toBeGreaterThan(-1);
+    expect(instructionsIdx).toBeGreaterThan(checklistIdx);
+  });
 });

--- a/src/components/AppContainer.tsx
+++ b/src/components/AppContainer.tsx
@@ -5,11 +5,17 @@ import AppInputs from "@/components/AppInputs";
 import Calculations from "@/components/Calculations";
 import InstructionsAndNotes from "@/components/InstructionsAndNotes";
 import MountainFlyingChecklist from "@/components/MountainFlyingChecklist";
-import Stepper from "@/components/Stepper";
+import Stepper, { type StepperStep } from "@/components/Stepper";
 import WorksheetHeader from "@/components/WorksheetHeader";
 import { useUrlState } from "@/utils/useUrlState";
 import { useTempUnit } from "@/utils/useTempUnit";
 import type { WorksheetData } from "@/utils/types";
+
+const WORKSHEET_STEPS: StepperStep[] = [
+  { id: "step-sortie", number: 1, label: "Sortie Details", status: "active" },
+  { id: "step-weather", number: 2, label: "Weather", status: "pending" },
+  { id: "step-decision", number: 3, label: "Decision", status: "pending" },
+];
 
 const getDefaultSortieDateTime = () => {
   const now = new Date();
@@ -124,13 +130,7 @@ export default function AppContainer() {
         useFahrenheit={useFahrenheit}
         onToggleTempUnit={toggleTempUnit}
       />
-      <Stepper
-        steps={[
-          { id: "step-sortie",   number: 1, label: "Sortie Details", status: "active" },
-          { id: "step-weather",  number: 2, label: "Weather",        status: "pending" },
-          { id: "step-decision", number: 3, label: "Decision",       status: "pending" },
-        ]}
-      />
+      <Stepper steps={WORKSHEET_STEPS} />
       <main className="flex-1 w-full flex justify-center px-2 md:px-8 pb-20">
         <div className="w-full max-w-5xl flex flex-col gap-16 items-center">
           <AppInputs

--- a/src/components/AppContainer.tsx
+++ b/src/components/AppContainer.tsx
@@ -5,6 +5,7 @@ import AppInputs from "@/components/AppInputs";
 import Calculations from "@/components/Calculations";
 import InstructionsAndNotes from "@/components/InstructionsAndNotes";
 import MountainFlyingChecklist from "@/components/MountainFlyingChecklist";
+import Stepper from "@/components/Stepper";
 import WorksheetHeader from "@/components/WorksheetHeader";
 import { useUrlState } from "@/utils/useUrlState";
 import { useTempUnit } from "@/utils/useTempUnit";
@@ -123,17 +124,26 @@ export default function AppContainer() {
         useFahrenheit={useFahrenheit}
         onToggleTempUnit={toggleTempUnit}
       />
+      <Stepper
+        steps={[
+          { id: "step-sortie",   number: 1, label: "Sortie Details", status: "active" },
+          { id: "step-weather",  number: 2, label: "Weather",        status: "pending" },
+          { id: "step-decision", number: 3, label: "Decision",       status: "pending" },
+        ]}
+      />
       <main className="flex-1 w-full flex justify-center px-2 md:px-8 pb-20">
         <div className="w-full max-w-5xl flex flex-col gap-16 items-center">
-          <InstructionsAndNotes />
           <AppInputs
             state={state}
             onStateUpdate={handleUpdate}
             weatherLastUpdated={weatherLastUpdated ?? undefined}
             useFahrenheit={useFahrenheit}
           />
-          <Calculations state={state} />
+          <section id="step-decision" className="w-full flex justify-center scroll-mt-[60px]">
+            <Calculations state={state} />
+          </section>
           <MountainFlyingChecklist />
+          <InstructionsAndNotes />
         </div>
       </main>
       <footer className="w-full py-4 px-2 md:px-8 text-center text-sm text-gray-600 dark:text-gray-400 border-t border-gray-200 dark:border-gray-800">

--- a/src/components/AppInputs.test.tsx
+++ b/src/components/AppInputs.test.tsx
@@ -239,6 +239,14 @@ describe("AppInputs", () => {
     expect(mockOnStateUpdate).toHaveBeenCalledTimes(3);
   });
 
+  it("wraps Sortie Details and Weather in semantic sections with stable anchor ids", () => {
+    const { container } = render(
+      <AppInputs state={defaultState} onStateUpdate={() => {}} />
+    );
+    expect(container.querySelector("#step-sortie")).not.toBeNull();
+    expect(container.querySelector("#step-weather")).not.toBeNull();
+  });
+
   it("renders with different initial states", () => {
     const populatedState = {
       ...defaultState,

--- a/src/components/AppInputs.tsx
+++ b/src/components/AppInputs.tsx
@@ -26,20 +26,24 @@ export default function AppInputs({
 
   return (
     <div className="flex w-full max-w-4xl flex-col gap-8">
-      <SortieInfo onUpdate={handleUpdate} initialData={state} />
-      <MountainQuals onUpdate={handleUpdate} initialData={state} />
-      <WeatherInfo
-        onUpdate={handleUpdate}
-        initialData={state}
-        lastUpdated={weatherLastUpdated}
-        useFahrenheit={useFahrenheit}
-      />
-      <AircraftPerformance
-        onUpdate={handleUpdate}
-        initialData={state}
-        worksheetData={state}
-        useFahrenheit={useFahrenheit}
-      />
+      <section id="step-sortie" className="flex flex-col gap-8 scroll-mt-[60px]">
+        <SortieInfo onUpdate={handleUpdate} initialData={state} />
+        <MountainQuals onUpdate={handleUpdate} initialData={state} />
+      </section>
+      <section id="step-weather" className="flex flex-col gap-8 scroll-mt-[60px]">
+        <WeatherInfo
+          onUpdate={handleUpdate}
+          initialData={state}
+          lastUpdated={weatherLastUpdated}
+          useFahrenheit={useFahrenheit}
+        />
+        <AircraftPerformance
+          onUpdate={handleUpdate}
+          initialData={state}
+          worksheetData={state}
+          useFahrenheit={useFahrenheit}
+        />
+      </section>
     </div>
   );
 }

--- a/src/components/Stepper.test.tsx
+++ b/src/components/Stepper.test.tsx
@@ -26,7 +26,7 @@ describe("Stepper", () => {
     expect(screen.getByRole("link", { name: /Decision/ })).toHaveAttribute("href", "#step-decision");
   });
 
-  it("uses the active-step className when activeId is explicitly set", () => {
+  it("marks the active step with data-active when activeId is explicitly set", () => {
     render(<Stepper steps={defaultSteps} activeId="step-weather" />);
     const weather = screen.getByRole("link", { name: /Weather/ });
     expect(weather).toHaveAttribute("data-active", "true");

--- a/src/components/Stepper.test.tsx
+++ b/src/components/Stepper.test.tsx
@@ -1,0 +1,34 @@
+// src/components/Stepper.test.tsx
+import { render, screen } from "@testing-library/react";
+import Stepper from "./Stepper";
+
+const defaultSteps = [
+  { id: "step-sortie",   number: 1, label: "Sortie Details", status: "active"   as const },
+  { id: "step-weather",  number: 2, label: "Weather",        status: "pending"  as const },
+  { id: "step-decision", number: 3, label: "Decision",       status: "pending"  as const },
+];
+
+describe("Stepper", () => {
+  it("renders all step labels and numbers", () => {
+    render(<Stepper steps={defaultSteps} />);
+    expect(screen.getByText("Sortie Details")).toBeInTheDocument();
+    expect(screen.getByText("Weather")).toBeInTheDocument();
+    expect(screen.getByText("Decision")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("renders each step as an anchor pointing to its section id", () => {
+    render(<Stepper steps={defaultSteps} />);
+    expect(screen.getByRole("link", { name: /Sortie Details/ })).toHaveAttribute("href", "#step-sortie");
+    expect(screen.getByRole("link", { name: /Weather/ })).toHaveAttribute("href", "#step-weather");
+    expect(screen.getByRole("link", { name: /Decision/ })).toHaveAttribute("href", "#step-decision");
+  });
+
+  it("uses the active-step className when activeId is explicitly set", () => {
+    render(<Stepper steps={defaultSteps} activeId="step-weather" />);
+    const weather = screen.getByRole("link", { name: /Weather/ });
+    expect(weather).toHaveAttribute("data-active", "true");
+  });
+});

--- a/src/components/Stepper.tsx
+++ b/src/components/Stepper.tsx
@@ -1,0 +1,118 @@
+// src/components/Stepper.tsx
+"use client";
+
+import { Fragment, useEffect, useState } from "react";
+import { ChevronRightIcon } from "@heroicons/react/24/outline";
+
+export type StepStatus = "pending" | "active" | "complete" | "warning";
+
+export interface StepperStep {
+  id: string;
+  number: number;
+  label: string;
+  status: StepStatus;
+  /** Optional small badge text rendered after the label (e.g. "8 of 11", "●", "⚠ 1"). */
+  badge?: string;
+}
+
+interface StepperProps {
+  steps: StepperStep[];
+  /** If set, this id is the active pill. If undefined, scroll-spy picks the active id. */
+  activeId?: string;
+}
+
+const circleBg: Record<StepStatus, string> = {
+  pending:  "bg-slate-300",
+  active:   "bg-slate-900",
+  complete: "bg-emerald-500",
+  warning:  "bg-amber-500",
+};
+
+const badgeColor: Record<StepStatus, string> = {
+  pending:  "text-slate-500",
+  active:   "text-slate-900",
+  complete: "text-emerald-600",
+  warning:  "text-amber-600",
+};
+
+export default function Stepper({ steps, activeId }: StepperProps) {
+  const [scrollSpyId, setScrollSpyId] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (activeId !== undefined) return; // explicit control wins
+    if (typeof IntersectionObserver === "undefined") return; // SSR / jsdom safety
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries.filter((e) => e.isIntersecting);
+        if (visible.length === 0) return;
+        const topMost = visible.sort(
+          (a, b) =>
+            a.target.getBoundingClientRect().top -
+            b.target.getBoundingClientRect().top
+        )[0];
+        setScrollSpyId(topMost.target.id);
+      },
+      { rootMargin: "-30% 0px -60% 0px", threshold: 0 }
+    );
+    steps.forEach((step) => {
+      const el = document.getElementById(step.id);
+      if (el) observer.observe(el);
+    });
+    return () => observer.disconnect();
+  }, [steps, activeId]);
+
+  const currentId = activeId ?? scrollSpyId ?? steps[0]?.id;
+
+  return (
+    <nav
+      aria-label="Worksheet steps"
+      className="sticky top-0 z-20 border-b border-slate-200 bg-slate-50/95 backdrop-blur supports-[backdrop-filter]:bg-slate-50/75"
+    >
+      <div className="mx-auto max-w-5xl px-4 py-2.5 md:px-6">
+        <ol className="flex items-center gap-1.5 overflow-x-auto text-sm">
+          {steps.map((step, i) => {
+            const isActive = currentId === step.id;
+            return (
+              <Fragment key={step.id}>
+                {i > 0 && (
+                  <li aria-hidden="true" className="text-slate-300">
+                    <ChevronRightIcon className="h-3.5 w-3.5" />
+                  </li>
+                )}
+                <li className="shrink-0">
+                  <a
+                    href={`#${step.id}`}
+                    data-active={isActive || undefined}
+                    className="flex items-center gap-2 rounded-full bg-white px-3 py-1.5 transition-all data-[active]:ring-2 data-[active]:ring-slate-900 data-[active]:shadow-sm"
+                  >
+                    <span
+                      className={`flex h-6 w-6 items-center justify-center rounded-full ${circleBg[step.status]} font-mono text-xs font-semibold text-white`}
+                    >
+                      {step.number}
+                    </span>
+                    <span
+                      className={
+                        isActive
+                          ? "font-medium text-slate-900"
+                          : "text-slate-700"
+                      }
+                    >
+                      {step.label}
+                    </span>
+                    {step.badge && (
+                      <span
+                        className={`text-xs font-medium ${badgeColor[step.status]}`}
+                      >
+                        {step.badge}
+                      </span>
+                    )}
+                  </a>
+                </li>
+              </Fragment>
+            );
+          })}
+        </ol>
+      </div>
+    </nav>
+  );
+}

--- a/src/components/Stepper.tsx
+++ b/src/components/Stepper.tsx
@@ -28,6 +28,13 @@ const circleBg: Record<StepStatus, string> = {
   warning:  "bg-amber-500",
 };
 
+const circleText: Record<StepStatus, string> = {
+  pending:  "text-slate-700",
+  active:   "text-white",
+  complete: "text-white",
+  warning:  "text-white",
+};
+
 const badgeColor: Record<StepStatus, string> = {
   pending:  "text-slate-500",
   active:   "text-slate-900",
@@ -86,7 +93,7 @@ export default function Stepper({ steps, activeId }: StepperProps) {
                     className="flex items-center gap-2 rounded-full bg-white px-3 py-1.5 transition-all data-[active]:ring-2 data-[active]:ring-slate-900 data-[active]:shadow-sm"
                   >
                     <span
-                      className={`flex h-6 w-6 items-center justify-center rounded-full ${circleBg[step.status]} font-mono text-xs font-semibold text-white`}
+                      className={`flex h-6 w-6 items-center justify-center rounded-full ${circleBg[step.status]} font-mono text-xs font-semibold ${circleText[step.status]}`}
                     >
                       {step.number}
                     </span>


### PR DESCRIPTION
## Summary

Introduces a sticky 3-pill stepper that scroll-spies the three logical worksheet sections (Sortie Details, Weather, Decision) and relocates `InstructionsAndNotes` from the top of the page to the bottom alongside `MountainFlyingChecklist`. This is **Phase 1 of a 5-phase redesign** — purely navigational scaffolding. Inner component refactors, slide-overs, and real step-status derivation are deferred to later phases.

- New `Stepper` component (`src/components/Stepper.tsx`) — sticky pill nav using `IntersectionObserver` for scroll-spy. Per-step status (`pending` / `active` / `complete` / `warning`) drives the numbered-circle color; `activeId` prop lets a caller override the spy. Built for Phase 3 to wire real derived state into.
- `AppInputs` children grouped under two semantic `<section>` anchors: `#step-sortie` (Sortie + Mountain Quals) and `#step-weather` (Weather + Aircraft Performance).
- `AppContainer` renders the Stepper as a sibling of `<main>` above the form, wraps `Calculations` in `#step-decision`, and moves `InstructionsAndNotes` to the bottom of the page.

Step statuses are hardcoded to `active / pending / pending` in this phase; Phase 3 derives them from real worksheet state.

## Plan

See `docs/superpowers/plans/2026-05-11-worksheet-ui-redesign-index.md` for the full 5-phase roadmap and `docs/superpowers/plans/2026-05-11-worksheet-ui-1-step-shell.md` for the Phase 1 plan executed by this PR.

## Test plan

- [x] `npx jest` — 479/479 passing across 34 suites
- [x] `npx tsc --noEmit` — no new errors from this branch
- [x] Stepper sticks to the viewport top on scroll
- [x] Clicking each pill scrolls to the right section, heading not hidden under the stepper (`scroll-mt-[60px]` offset)
- [x] Scroll-spy highlights the pill matching the section in view
- [x] `Mountain Flying Checklist` and `Instructions and Notes` both render at the bottom in that order, both still collapsible
- [x] No browser console errors on page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)