### PR TITLE
Fix #116: relative time uses days/weeks for spans >24h

### DIFF
--- a/src/components/SortieInfo.test.tsx
+++ b/src/components/SortieInfo.test.tsx
@@ -149,6 +149,59 @@ describe("SortieInfo", () => {
   });
 });
 
+describe("SortieInfo - sortie timing relative display", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(Date.UTC(2026, 4, 15, 0, 0)));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("shows hours when less than 24 hours in the future", () => {
+    const initialData = { ...defaultInitialData, date: "2026-05-15", time: "12:00" };
+    render(<SortieInfo onUpdate={jest.fn()} initialData={initialData} />);
+    expect(screen.getByText(/12 hours from now/)).toBeInTheDocument();
+  });
+
+  it("shows days when more than 24 hours and within a week in the future", () => {
+    const initialData = { ...defaultInitialData, date: "2026-05-20", time: "02:00" };
+    render(<SortieInfo onUpdate={jest.fn()} initialData={initialData} />);
+    expect(screen.getByText(/5 days from now/)).toBeInTheDocument();
+  });
+
+  it("uses singular 'day' for exactly 24 hours away", () => {
+    const initialData = { ...defaultInitialData, date: "2026-05-16", time: "00:00" };
+    render(<SortieInfo onUpdate={jest.fn()} initialData={initialData} />);
+    expect(screen.getByText(/1 day from now/)).toBeInTheDocument();
+  });
+
+  it("shows days when in the past within a week", () => {
+    const initialData = { ...defaultInitialData, date: "2026-05-12", time: "00:00" };
+    render(<SortieInfo onUpdate={jest.fn()} initialData={initialData} />);
+    expect(screen.getByText(/3 days ago/)).toBeInTheDocument();
+  });
+
+  it("shows 'more than a week from now' when more than 7 days in the future", () => {
+    const initialData = { ...defaultInitialData, date: "2026-05-23", time: "00:00" };
+    render(<SortieInfo onUpdate={jest.fn()} initialData={initialData} />);
+    expect(screen.getByText(/more than a week from now/)).toBeInTheDocument();
+  });
+
+  it("shows 'more than a week ago' when more than 7 days in the past", () => {
+    const initialData = { ...defaultInitialData, date: "2026-05-07", time: "00:00" };
+    render(<SortieInfo onUpdate={jest.fn()} initialData={initialData} />);
+    expect(screen.getByText(/more than a week ago/)).toBeInTheDocument();
+  });
+
+  it("still shows days at exactly 7 days away", () => {
+    const initialData = { ...defaultInitialData, date: "2026-05-22", time: "00:00" };
+    render(<SortieInfo onUpdate={jest.fn()} initialData={initialData} />);
+    expect(screen.getByText(/7 days from now/)).toBeInTheDocument();
+  });
+});
+
 describe("SortieInfo - position field wiring", () => {
   it("calls onUpdate with both route and position when valid coords are entered", async () => {
     jest.useFakeTimers();

--- a/src/components/SortieInfo.tsx
+++ b/src/components/SortieInfo.tsx
@@ -202,16 +202,29 @@ export default function SortieInfo({ initialData, onUpdate }: SortieInfoProps) {
     }
 
     const isFuture = diffMinutes > 0;
+    const suffix = isFuture ? "from now" : "ago";
+    const MINUTES_PER_DAY = 60 * 24;
+    const MINUTES_PER_WEEK = MINUTES_PER_DAY * 7;
+
+    if (absMinutes > MINUTES_PER_WEEK) {
+      return `${localDisplay}, more than a week ${suffix}`;
+    }
+
+    if (absMinutes >= MINUTES_PER_DAY) {
+      const days = Math.round(absMinutes / MINUTES_PER_DAY);
+      const dayLabel = `${days} day${days === 1 ? "" : "s"}`;
+      return `${localDisplay}, ${dayLabel} ${suffix}`;
+    }
 
     if (absMinutes < 60) {
       const minutes = absMinutes;
       const minuteLabel = `${minutes} minute${minutes === 1 ? "" : "s"}`;
-      return `${localDisplay}, ${minuteLabel} ${isFuture ? "from now" : "ago"}`;
+      return `${localDisplay}, ${minuteLabel} ${suffix}`;
     }
 
     const hours = Math.round(absMinutes / 60);
     const hourLabel = `${hours} hour${hours === 1 ? "" : "s"}`;
-    return `${localDisplay}, ${hourLabel} ${isFuture ? "from now" : "ago"}`;
+    return `${localDisplay}, ${hourLabel} ${suffix}`;
   }, [formData.date, formData.time, currentTime]);
 
   return (


### PR DESCRIPTION
## Summary
- Closes #116. The relative-time suffix on the sortie When line now switches units as the span grows: minutes (<1h), hours (<24h), days (24h–7d), and "more than a week" beyond 7 days.
- 126 hours → "5 days from now"; 475 hours ago → "more than a week ago".
- Adds 7 component tests covering each band plus the boundary at exactly 7 days.

## Test plan
- [x] `npx jest src/components/SortieInfo.test.tsx` — 24/24 pass
- [x] `npx jest` — 528/528 pass
- [x] `npm run lint` — clean
- [ ] Manual: open the worksheet, set a date >7 days out, confirm "more than a week from now"

🤖 Generated with [Claude Code](https://claude.com/claude-code)