### PR TITLE
Add Open in SkyVector button (#101)

### DIFF
--- a/docs/superpowers/plans/2026-05-17-skyvector-button.md
+++ b/docs/superpowers/plans/2026-05-17-skyvector-button.md
@@ -1,0 +1,516 @@
+# Open Route in SkyVector — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a button in the Sortie Info "Where" section that opens the current departure → operating → arrival route on skyvector.com in a new tab.
+
+**Architecture:** One new pure utility module (`src/utils/skyvector.ts`) exposes `latLonToDmsWaypoint` and `buildSkyvectorUrl`. The existing `SortieInfo` component renders a `<button>` that calls `buildSkyvectorUrl` against `formData.airport` and `formData.position`, disables itself when the helper returns `null`, and opens the URL with `window.open` on click.
+
+**Tech Stack:** TypeScript, React 19 / Next.js 16 App Router, Jest + React Testing Library, Tailwind CSS v4. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-05-17-skyvector-button-design.md`
+
+---
+
+## File Structure
+
+**New files:**
+- `src/utils/skyvector.ts` — pure functions, ~50 lines. Exports `latLonToDmsWaypoint(lat, lon)` and `buildSkyvectorUrl({ departure, arrival, operating })`.
+- `src/utils/__tests__/skyvector.test.ts` — unit tests for both helpers.
+
+**Modified files:**
+- `src/components/SortieInfo.tsx` — adds an "Open in SkyVector" button at the bottom of the **Where** section, before the `Pilot Qualifications` section. No new state or props.
+- `src/components/SortieInfo.test.tsx` — adds tests for the button's disabled logic and `window.open` invocation.
+
+---
+
+## Task 1: DMS waypoint converter — happy path
+
+**Files:**
+- Create: `src/utils/skyvector.ts`
+- Create: `src/utils/__tests__/skyvector.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/utils/__tests__/skyvector.test.ts`:
+
+```ts
+import { latLonToDmsWaypoint } from "@/utils/skyvector";
+
+describe("latLonToDmsWaypoint", () => {
+  it("formats positive lat / negative lon", () => {
+    expect(latLonToDmsWaypoint(40.5023, -110.7456)).toBe("403008N1104444W");
+  });
+
+  it("formats negative lat / positive lon", () => {
+    expect(latLonToDmsWaypoint(-33.8688, 151.2093)).toBe("335208S1511233E");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run: `npx jest src/utils/__tests__/skyvector.test.ts -t "latLonToDmsWaypoint"`
+Expected: FAIL with `Cannot find module '@/utils/skyvector'` (or similar resolution error).
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `src/utils/skyvector.ts`:
+
+```ts
+const pad = (n: number, width: number): string =>
+  String(n).padStart(width, "0");
+
+export function latLonToDmsWaypoint(lat: number, lon: number): string {
+  const formatComponent = (value: number, degreeWidth: number, maxDeg: number): { deg: number; min: number; sec: number } => {
+    const abs = Math.abs(value);
+    let deg = Math.floor(abs);
+    let minTotal = (abs - deg) * 60;
+    let min = Math.floor(minTotal);
+    let sec = Math.round((minTotal - min) * 60);
+    if (sec === 60) {
+      sec = 0;
+      min += 1;
+    }
+    if (min === 60) {
+      min = 0;
+      deg += 1;
+    }
+    if (deg > maxDeg) deg = maxDeg;
+    return { deg, min, sec };
+  };
+
+  const latParts = formatComponent(lat, 2, 90);
+  const lonParts = formatComponent(lon, 3, 180);
+  const latSuffix = lat < 0 ? "S" : "N";
+  const lonSuffix = lon < 0 ? "W" : "E";
+
+  return (
+    pad(latParts.deg, 2) + pad(latParts.min, 2) + pad(latParts.sec, 2) + latSuffix +
+    pad(lonParts.deg, 3) + pad(lonParts.min, 2) + pad(lonParts.sec, 2) + lonSuffix
+  );
+}
+```
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+Run: `npx jest src/utils/__tests__/skyvector.test.ts -t "latLonToDmsWaypoint"`
+Expected: 2 passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/skyvector.ts src/utils/__tests__/skyvector.test.ts
+git commit -m "Add DMS waypoint converter for SkyVector route URLs"
+```
+
+---
+
+## Task 2: DMS converter — edge cases (rollover, zero, poles, neg-zero)
+
+**Files:**
+- Modify: `src/utils/__tests__/skyvector.test.ts` — append cases
+- Modify: `src/utils/skyvector.ts` — only if tests fail
+
+- [ ] **Step 1: Add failing edge-case tests**
+
+Append these `it` blocks inside the existing `describe("latLonToDmsWaypoint", ...)` in `src/utils/__tests__/skyvector.test.ts`:
+
+```ts
+it("formats exact integer degrees", () => {
+  expect(latLonToDmsWaypoint(40, -110)).toBe("400000N1100000W");
+});
+
+it("formats zero coordinates with N/E suffix and correct widths", () => {
+  expect(latLonToDmsWaypoint(0, 0)).toBe("000000N0000000E");
+});
+
+it("treats negative zero as positive (N/E)", () => {
+  expect(latLonToDmsWaypoint(-0, -0)).toBe("000000N0000000E");
+});
+
+it("rolls seconds 60 over into minutes", () => {
+  // 40 + 59.9/60 + 59.6/3600 deg places seconds at ~59.6, which rounds to 60
+  // and should carry into minutes.
+  const lat = 40 + 59 / 60 + 59.6 / 3600;
+  expect(latLonToDmsWaypoint(lat, 0)).toBe("410000N0000000E");
+});
+
+it("clamps poles and anti-meridian", () => {
+  expect(latLonToDmsWaypoint(89.9999, 179.9999)).toBe("900000N1800000E");
+  expect(latLonToDmsWaypoint(-89.9999, -179.9999)).toBe("900000S1800000W");
+});
+```
+
+- [ ] **Step 2: Run the tests and confirm whether they pass or fail**
+
+Run: `npx jest src/utils/__tests__/skyvector.test.ts -t "latLonToDmsWaypoint"`
+Expected: all pass with the Task 1 implementation (the rollover/clamp logic is already there). If any case fails, narrow the failing test and adjust the implementation in `src/utils/skyvector.ts` minimally until green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/utils/__tests__/skyvector.test.ts src/utils/skyvector.ts
+git commit -m "Cover edge cases in DMS waypoint converter"
+```
+
+---
+
+## Task 3: `buildSkyvectorUrl` happy path
+
+**Files:**
+- Modify: `src/utils/__tests__/skyvector.test.ts`
+- Modify: `src/utils/skyvector.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/utils/__tests__/skyvector.test.ts`:
+
+```ts
+import { buildSkyvectorUrl } from "@/utils/skyvector";
+
+describe("buildSkyvectorUrl", () => {
+  it("builds a three-waypoint URL when all fields are set", () => {
+    expect(
+      buildSkyvectorUrl({
+        departure: "KPVU",
+        arrival: "KSGU",
+        operating: [40.5023, -110.7456],
+      })
+    ).toBe(
+      "https://skyvector.com/?fpl=KPVU%20403008N1104444W%20KSGU"
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run: `npx jest src/utils/__tests__/skyvector.test.ts -t "buildSkyvectorUrl"`
+Expected: FAIL — `buildSkyvectorUrl is not a function` or similar.
+
+- [ ] **Step 3: Implement `buildSkyvectorUrl`**
+
+Append to `src/utils/skyvector.ts`:
+
+```ts
+export interface BuildSkyvectorUrlInput {
+  departure: string;
+  arrival: string;
+  operating: [number | null, number | null] | null;
+}
+
+export function buildSkyvectorUrl(input: BuildSkyvectorUrlInput): string | null {
+  const dep = input.departure.trim().toUpperCase();
+  const arr = input.arrival.trim().toUpperCase();
+  if (!dep || !arr) return null;
+
+  const waypoints: string[] = [dep];
+  if (
+    input.operating &&
+    input.operating[0] !== null &&
+    input.operating[1] !== null
+  ) {
+    waypoints.push(latLonToDmsWaypoint(input.operating[0], input.operating[1]));
+  }
+  waypoints.push(arr);
+
+  return `https://skyvector.com/?fpl=${waypoints.join("%20")}`;
+}
+```
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+Run: `npx jest src/utils/__tests__/skyvector.test.ts -t "buildSkyvectorUrl"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/skyvector.ts src/utils/__tests__/skyvector.test.ts
+git commit -m "Add buildSkyvectorUrl with three-waypoint route"
+```
+
+---
+
+## Task 4: `buildSkyvectorUrl` edge cases
+
+**Files:**
+- Modify: `src/utils/__tests__/skyvector.test.ts`
+- Modify: `src/utils/skyvector.ts` (only if needed)
+
+- [ ] **Step 1: Add failing edge-case tests**
+
+Append inside the existing `describe("buildSkyvectorUrl", ...)`:
+
+```ts
+it("omits operating waypoint when operating is null", () => {
+  expect(
+    buildSkyvectorUrl({ departure: "KPVU", arrival: "KSGU", operating: null })
+  ).toBe("https://skyvector.com/?fpl=KPVU%20KSGU");
+});
+
+it("omits operating waypoint when one coordinate is null", () => {
+  expect(
+    buildSkyvectorUrl({
+      departure: "KPVU",
+      arrival: "KSGU",
+      operating: [40.5, null],
+    })
+  ).toBe("https://skyvector.com/?fpl=KPVU%20KSGU");
+});
+
+it("returns null when departure is empty", () => {
+  expect(
+    buildSkyvectorUrl({ departure: "", arrival: "KSGU", operating: null })
+  ).toBeNull();
+});
+
+it("returns null when arrival is whitespace-only", () => {
+  expect(
+    buildSkyvectorUrl({ departure: "KPVU", arrival: "   ", operating: null })
+  ).toBeNull();
+});
+
+it("uppercases and trims airport identifiers", () => {
+  expect(
+    buildSkyvectorUrl({
+      departure: " kpvu ",
+      arrival: "kSgU",
+      operating: null,
+    })
+  ).toBe("https://skyvector.com/?fpl=KPVU%20KSGU");
+});
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `npx jest src/utils/__tests__/skyvector.test.ts`
+Expected: all pass with the Task 3 implementation. If any fail, narrow and fix in `src/utils/skyvector.ts`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/utils/__tests__/skyvector.test.ts src/utils/skyvector.ts
+git commit -m "Cover buildSkyvectorUrl edge cases"
+```
+
+---
+
+## Task 5: Render the "Open in SkyVector" button (disabled state first)
+
+**Files:**
+- Modify: `src/components/SortieInfo.test.tsx`
+- Modify: `src/components/SortieInfo.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a new `describe` block to `src/components/SortieInfo.test.tsx` (after the existing top-level `describe("SortieInfo", ...)` — or inside it, near the bottom):
+
+```ts
+describe("SortieInfo — SkyVector button", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the button disabled when both airports are blank", () => {
+    render(<SortieInfo onUpdate={jest.fn()} initialData={defaultInitialData} />);
+    const button = screen.getByRole("button", { name: /open in skyvector/i });
+    expect(button).toBeDisabled();
+  });
+
+  it("renders the button disabled when only departure is set", () => {
+    const initialData = { ...defaultInitialData, airport: ["KPVU", ""] as [string, string] };
+    render(<SortieInfo onUpdate={jest.fn()} initialData={initialData} />);
+    const button = screen.getByRole("button", { name: /open in skyvector/i });
+    expect(button).toBeDisabled();
+  });
+
+  it("renders the button disabled when only arrival is set", () => {
+    const initialData = { ...defaultInitialData, airport: ["", "KSGU"] as [string, string] };
+    render(<SortieInfo onUpdate={jest.fn()} initialData={initialData} />);
+    const button = screen.getByRole("button", { name: /open in skyvector/i });
+    expect(button).toBeDisabled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run: `npx jest src/components/SortieInfo.test.tsx -t "SkyVector"`
+Expected: FAIL — `Unable to find an accessible element with the role "button" and name /open in skyvector/i`.
+
+- [ ] **Step 3: Add the button to `SortieInfo`**
+
+Open `src/components/SortieInfo.tsx` and update the imports at the top to include the SkyVector helper:
+
+```ts
+import { buildSkyvectorUrl } from "@/utils/skyvector";
+```
+
+Find the JSX for the **Where** section. It currently ends with the closing tags of the grid (`</div></div>`) just before the `Pilot Qualifications` block. Insert this immediately after the closing `</div>` of the grid and before the closing `</div>` of the Where section (i.e., a sibling of the grid, still inside the Where section):
+
+```tsx
+{(() => {
+  const skyvectorUrl = buildSkyvectorUrl({
+    departure: formData.airport?.[0] ?? "",
+    arrival: formData.airport?.[1] ?? "",
+    operating: formData.position ?? null,
+  });
+  const disabled = skyvectorUrl === null;
+  return (
+    <div className="mt-4">
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() => {
+          if (skyvectorUrl) {
+            window.open(skyvectorUrl, "_blank", "noopener,noreferrer");
+          }
+        }}
+        title={disabled ? "Set departure and arrival airports" : "Open route in SkyVector"}
+        className="inline-flex items-center gap-1.5 rounded-md border border-slate-300 px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-800"
+      >
+        Open in SkyVector
+      </button>
+    </div>
+  );
+})()}
+```
+
+- [ ] **Step 4: Run the tests and verify they pass**
+
+Run: `npx jest src/components/SortieInfo.test.tsx -t "SkyVector"`
+Expected: 3 passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/SortieInfo.tsx src/components/SortieInfo.test.tsx
+git commit -m "Add disabled SkyVector button to Where section"
+```
+
+---
+
+## Task 6: Button is enabled and opens URL when both airports are set
+
+**Files:**
+- Modify: `src/components/SortieInfo.test.tsx`
+
+- [ ] **Step 1: Add failing tests**
+
+Append inside the `describe("SortieInfo — SkyVector button", ...)` block:
+
+```ts
+it("is enabled and opens a two-waypoint URL when only airports are set", () => {
+  const openSpy = jest.spyOn(window, "open").mockImplementation(() => null);
+  const initialData = {
+    ...defaultInitialData,
+    airport: ["KPVU", "KSGU"] as [string, string],
+  };
+  render(<SortieInfo onUpdate={jest.fn()} initialData={initialData} />);
+
+  const button = screen.getByRole("button", { name: /open in skyvector/i });
+  expect(button).not.toBeDisabled();
+
+  fireEvent.click(button);
+  expect(openSpy).toHaveBeenCalledWith(
+    "https://skyvector.com/?fpl=KPVU%20KSGU",
+    "_blank",
+    "noopener,noreferrer"
+  );
+
+  openSpy.mockRestore();
+});
+
+it("opens a three-waypoint URL when operating coordinates are set", () => {
+  const openSpy = jest.spyOn(window, "open").mockImplementation(() => null);
+  const initialData = {
+    ...defaultInitialData,
+    airport: ["KPVU", "KSGU"] as [string, string],
+    position: [40.5023, -110.7456] as [number | null, number | null],
+  };
+  render(<SortieInfo onUpdate={jest.fn()} initialData={initialData} />);
+
+  fireEvent.click(screen.getByRole("button", { name: /open in skyvector/i }));
+  expect(openSpy).toHaveBeenCalledWith(
+    "https://skyvector.com/?fpl=KPVU%20403008N1104444W%20KSGU",
+    "_blank",
+    "noopener,noreferrer"
+  );
+
+  openSpy.mockRestore();
+});
+
+it("falls back to two-waypoint URL when operating position has nulls", () => {
+  const openSpy = jest.spyOn(window, "open").mockImplementation(() => null);
+  const initialData = {
+    ...defaultInitialData,
+    airport: ["KPVU", "KSGU"] as [string, string],
+    position: [null, null] as [number | null, number | null],
+  };
+  render(<SortieInfo onUpdate={jest.fn()} initialData={initialData} />);
+
+  fireEvent.click(screen.getByRole("button", { name: /open in skyvector/i }));
+  expect(openSpy).toHaveBeenCalledWith(
+    "https://skyvector.com/?fpl=KPVU%20KSGU",
+    "_blank",
+    "noopener,noreferrer"
+  );
+
+  openSpy.mockRestore();
+});
+```
+
+- [ ] **Step 2: Run the tests and verify they pass**
+
+Run: `npx jest src/components/SortieInfo.test.tsx -t "SkyVector"`
+Expected: 6 passing (3 from Task 5 + 3 new). No implementation changes needed — Task 5 already wired up `window.open` and the URL builder.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/SortieInfo.test.tsx
+git commit -m "Test SkyVector button opens URL with correct waypoints"
+```
+
+---
+
+## Task 7: Full verification — lint, typecheck, tests
+
+**Files:** (none modified)
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `npm test -- --silent`
+Expected: all suites pass. If anything outside the new files fails, investigate before continuing.
+
+- [ ] **Step 2: Run lint**
+
+Run: `npm run lint`
+Expected: no errors. If lint reports issues in the new files, fix them and re-run.
+
+- [ ] **Step 3: Run the production build (typecheck)**
+
+Run: `npm run build`
+Expected: build completes without TypeScript errors.
+
+- [ ] **Step 4: Commit any fixes (if needed)**
+
+If steps 2 or 3 required code changes:
+
+```bash
+git add -A
+git commit -m "Fix lint/typecheck for SkyVector button"
+```
+
+If nothing changed, skip this step.
+
+---
+
+## Done criteria
+
+- `npm test`, `npm run lint`, and `npm run build` all pass.
+- A user with departure and arrival airports filled in sees an enabled "Open in SkyVector" button in the **Where** section that opens skyvector.com in a new tab with the route prefilled.
+- A user without both airports sees the button disabled with an explanatory tooltip.
+- The operating waypoint is included as a DMS coordinate when `position` is parsed; otherwise the URL is a two-waypoint route.

--- a/docs/superpowers/specs/2026-05-17-skyvector-button-design.md
+++ b/docs/superpowers/specs/2026-05-17-skyvector-button-design.md
@@ -1,0 +1,176 @@
+# Open Route in SkyVector — Design
+
+**Issue:** #101 — Add a button to open the route visualized in SkyVector
+**Date:** 2026-05-17
+
+## Goal
+
+Give pilots a one-click way to open the worksheet's planned route on
+[skyvector.com](https://skyvector.com) in a new tab. The route is
+`departure → operating → arrival`, using the airport identifiers and the parsed
+Area-of-Operations coordinates already present in worksheet state.
+
+## User experience
+
+A button labeled **"Open in SkyVector"** appears at the bottom of the
+**Where** section in `SortieInfo`, directly after the grid that contains
+the Departure, Arrival, Operating Altitude, Area of Operations, and
+Aircraft Takeoff Weight inputs.
+
+- Enabled when both Departure Airport and Arrival Airport are non-blank
+  (after trim).
+- Disabled otherwise, with the title `Set departure and arrival airports`.
+- Clicking calls `window.open(url, "_blank", "noopener,noreferrer")`.
+
+The button never blocks worksheet entry — it is purely additive.
+
+## Architecture
+
+One new pure utility module and a button rendered in an existing component:
+
+- `src/utils/skyvector.ts` — pure functions, no React, no side effects.
+  - `latLonToDmsWaypoint(lat: number, lon: number): string`
+  - `buildSkyvectorUrl(input): string | null`
+- `src/components/SortieInfo.tsx` — adds the button. Reads from the
+  existing `formData` (no new props, no new state).
+
+A unit test file `src/utils/__tests__/skyvector.test.ts` covers the
+utility; component tests are added to the existing
+`src/components/SortieInfo.test.tsx`.
+
+## Data flow
+
+1. The button component reads `formData.airport[0]`,
+   `formData.airport[1]`, and `formData.position` from the same
+   `SortieInfo` state the rest of the **Where** section uses.
+2. It calls `buildSkyvectorUrl({ departure, arrival, operating })` where
+   `operating` is `formData.position` if both entries are non-null, else
+   `null`.
+3. If the helper returns `null`, the button renders disabled. Otherwise
+   the button is enabled and the URL is used in `window.open` on click.
+
+There is no derived React state, no `useEffect`, and no caching. The URL
+is computed on each render — it's a few string operations on values
+already in scope.
+
+## URL construction
+
+Base URL: `https://skyvector.com/?fpl=` followed by waypoints joined by
+`%20`.
+
+Waypoints, in order:
+1. Departure airport identifier (trimmed, uppercased).
+2. Operating waypoint, **only when** `formData.position` has both lat
+   and lon non-null. Encoded via `latLonToDmsWaypoint`.
+3. Arrival airport identifier (trimmed, uppercased).
+
+`buildSkyvectorUrl` returns `null` if departure or arrival is empty
+after trim — this is the single signal the button uses to decide its
+disabled state.
+
+### Examples
+
+- All three set:
+  `https://skyvector.com/?fpl=KPVU%20403008N1104444W%20KSGU`
+- Operating blank or unparsed:
+  `https://skyvector.com/?fpl=KPVU%20KSGU`
+
+## DMS waypoint format
+
+SkyVector accepts ICAO-style coordinate waypoints in the form
+`DDMMSS[NS]DDDMMSS[EW]` (no decimals, integer seconds). The conversion:
+
+1. Take the absolute value of the coordinate.
+2. Compute integer degrees, integer minutes, and seconds rounded to the
+   nearest integer.
+3. Carry overflow: 60 seconds → +1 minute, 60 minutes → +1 degree.
+4. Clamp degrees to ≤90 for latitude and ≤180 for longitude as a
+   floating-point safety net (e.g. inputs like `89.999999...` after
+   rounding).
+5. Format with `padStart`: degrees → 2 digits (lat) or 3 digits (lon);
+   minutes and seconds → 2 digits each.
+6. Suffix: `N` if `lat ≥ 0` else `S`; `E` if `lon ≥ 0` else `W`. A
+   negative-zero coordinate (`-0`) is treated as positive — use
+   `lat < 0` not `Object.is(lat, -0)` to pick the suffix.
+
+### Conversion examples
+
+| Input lat, lon         | Output                  |
+|------------------------|-------------------------|
+| 40.5023, -110.7456     | `403008N1104444W`       |
+| 40.0, -110.0           | `400000N1100000W`       |
+| 0, 0                   | `000000N0000000E`       |
+| -33.8688, 151.2093     | `335208S1511234E`       |
+| 89.9999, 179.9999      | `900000N1800000E` (clamped) |
+
+The latitude block is `DDMMSS` (6 digits) and the longitude block is
+`DDDMMSS` (7 digits), each followed by its hemisphere suffix.
+
+## Edge cases
+
+- Either airport blank or whitespace-only → button disabled, no URL.
+- Operating `position` is `[null, null]` (route field empty or free text
+  that didn't parse) → two-waypoint URL; button stays enabled.
+- ICAO with surrounding whitespace or lowercase letters → trimmed and
+  uppercased before insertion.
+- Exactly-zero latitude or longitude is a valid coordinate (the missing
+  signal is `null`, not `0`).
+- Coordinate near the poles or anti-meridian → degree value clamped so
+  the formatter never produces 4-digit-degree output.
+- Popup blocked → not handled. `window.open` is fire-and-forget,
+  consistent with the rest of this codebase. The user will see their
+  browser's standard popup-blocked indicator.
+
+## Testing
+
+### `src/utils/__tests__/skyvector.test.ts`
+
+`latLonToDmsWaypoint`:
+- Positive latitude, positive longitude.
+- Negative latitude, negative longitude.
+- Exact integer degrees (no fractional minutes/seconds).
+- Rollover when seconds round to 60 (e.g. inputs that produce
+  `…59.6"` seconds carrying into the minutes field).
+- `0, 0` produces `000000N0000000E` (latitude block 6 digits, longitude
+  block 7 digits, both with positive suffix).
+- `-0` latitude and `-0` longitude produce `N`/`E` suffixes.
+- Values at ±90 / ±180 produce clamped, 2- or 3-digit degree output.
+
+`buildSkyvectorUrl`:
+- All three fields set → exact expected URL (literal string match — catches
+  `%20` vs `+` regressions).
+- Operating `null` → two-waypoint URL.
+- Departure blank string → returns `null`.
+- Arrival whitespace-only → returns `null`.
+- Lowercase ICAO → uppercased in the output URL.
+- Operating with one `null` coordinate → treated as missing
+  (two-waypoint URL).
+
+### `src/components/SortieInfo.test.tsx`
+
+- Button is disabled when departure missing.
+- Button is disabled when arrival missing.
+- Button is enabled and `window.open` is called with the expected URL
+  when both airports and operating coordinates are set (mock
+  `window.open`).
+- Button is enabled with a two-waypoint URL when operating `position`
+  is `[null, null]`.
+- `window.open` is called with `"_blank"` and `"noopener,noreferrer"`.
+
+## What this design does **not** include
+
+- No pretty-label passthrough for operating airports or VOR-RDs — the
+  operating waypoint is always a coordinate. (Option B/C in the
+  approaches discussion.) This can be added later without a schema
+  change.
+- No support for printing or copying the SkyVector URL.
+- No UX surfacing of popup-blocked errors.
+- No second button location (ActionBar) — discoverability is satisfied
+  by the inline placement next to the inputs the button uses.
+
+## Files touched
+
+- `src/utils/skyvector.ts` (new)
+- `src/utils/__tests__/skyvector.test.ts` (new)
+- `src/components/SortieInfo.tsx` (button added; no other changes)
+- `src/components/SortieInfo.test.tsx` (button tests added)

--- a/docs/superpowers/specs/2026-05-17-skyvector-button-design.md
+++ b/docs/superpowers/specs/2026-05-17-skyvector-button-design.md
@@ -44,7 +44,8 @@ utility; component tests are added to the existing
    `formData.airport[1]`, and `formData.position` from the same
    `SortieInfo` state the rest of the **Where** section uses.
 2. It calls `buildSkyvectorUrl({ departure, arrival, operating })` where
-   `operating` is `formData.position` if both entries are non-null, else
+   `operating` is `formData.position` (a `[number | null, number | null]`
+   tuple). The helper internally skips the waypoint when either entry is
    `null`.
 3. If the helper returns `null`, the button renders disabled. Otherwise
    the button is enabled and the URL is used in `window.open` on click.

--- a/docs/superpowers/specs/2026-05-17-skyvector-button-design.md
+++ b/docs/superpowers/specs/2026-05-17-skyvector-button-design.md
@@ -100,7 +100,7 @@ SkyVector accepts ICAO-style coordinate waypoints in the form
 | 40.5023, -110.7456     | `403008N1104444W`       |
 | 40.0, -110.0           | `400000N1100000W`       |
 | 0, 0                   | `000000N0000000E`       |
-| -33.8688, 151.2093     | `335208S1511234E`       |
+| -33.8688, 151.2093     | `335208S1511233E`       |
 | 89.9999, 179.9999      | `900000N1800000E` (clamped) |
 
 The latitude block is `DDMMSS` (6 digits) and the longitude block is

--- a/src/components/SortieInfo.test.tsx
+++ b/src/components/SortieInfo.test.tsx
@@ -203,6 +203,16 @@ describe("SortieInfo - sortie timing relative display", () => {
 });
 
 describe("SortieInfo — SkyVector button", () => {
+  let openSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    openSpy = jest.spyOn(window, "open").mockImplementation(() => null);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it("renders the button disabled when both airports are blank", () => {
     render(<SortieInfo onUpdate={jest.fn()} initialData={defaultInitialData} />);
     const button = screen.getByRole("button", { name: /open in skyvector/i });
@@ -224,7 +234,6 @@ describe("SortieInfo — SkyVector button", () => {
   });
 
   it("is enabled and opens a two-waypoint URL when only airports are set", () => {
-    const openSpy = jest.spyOn(window, "open").mockImplementation(() => null);
     const initialData = {
       ...defaultInitialData,
       airport: ["KPVU", "KSGU"] as [string, string],
@@ -240,12 +249,9 @@ describe("SortieInfo — SkyVector button", () => {
       "_blank",
       "noopener,noreferrer"
     );
-
-    openSpy.mockRestore();
   });
 
   it("opens a three-waypoint URL when operating coordinates are set", () => {
-    const openSpy = jest.spyOn(window, "open").mockImplementation(() => null);
     const initialData = {
       ...defaultInitialData,
       airport: ["KPVU", "KSGU"] as [string, string],
@@ -259,12 +265,9 @@ describe("SortieInfo — SkyVector button", () => {
       "_blank",
       "noopener,noreferrer"
     );
-
-    openSpy.mockRestore();
   });
 
   it("falls back to two-waypoint URL when operating position has nulls", () => {
-    const openSpy = jest.spyOn(window, "open").mockImplementation(() => null);
     const initialData = {
       ...defaultInitialData,
       airport: ["KPVU", "KSGU"] as [string, string],
@@ -278,8 +281,6 @@ describe("SortieInfo — SkyVector button", () => {
       "_blank",
       "noopener,noreferrer"
     );
-
-    openSpy.mockRestore();
   });
 });
 

--- a/src/components/SortieInfo.test.tsx
+++ b/src/components/SortieInfo.test.tsx
@@ -203,10 +203,6 @@ describe("SortieInfo - sortie timing relative display", () => {
 });
 
 describe("SortieInfo — SkyVector button", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   it("renders the button disabled when both airports are blank", () => {
     render(<SortieInfo onUpdate={jest.fn()} initialData={defaultInitialData} />);
     const button = screen.getByRole("button", { name: /open in skyvector/i });

--- a/src/components/SortieInfo.test.tsx
+++ b/src/components/SortieInfo.test.tsx
@@ -222,6 +222,65 @@ describe("SortieInfo — SkyVector button", () => {
     const button = screen.getByRole("button", { name: /open in skyvector/i });
     expect(button).toBeDisabled();
   });
+
+  it("is enabled and opens a two-waypoint URL when only airports are set", () => {
+    const openSpy = jest.spyOn(window, "open").mockImplementation(() => null);
+    const initialData = {
+      ...defaultInitialData,
+      airport: ["KPVU", "KSGU"] as [string, string],
+    };
+    render(<SortieInfo onUpdate={jest.fn()} initialData={initialData} />);
+
+    const button = screen.getByRole("button", { name: /open in skyvector/i });
+    expect(button).not.toBeDisabled();
+
+    fireEvent.click(button);
+    expect(openSpy).toHaveBeenCalledWith(
+      "https://skyvector.com/?fpl=KPVU%20KSGU",
+      "_blank",
+      "noopener,noreferrer"
+    );
+
+    openSpy.mockRestore();
+  });
+
+  it("opens a three-waypoint URL when operating coordinates are set", () => {
+    const openSpy = jest.spyOn(window, "open").mockImplementation(() => null);
+    const initialData = {
+      ...defaultInitialData,
+      airport: ["KPVU", "KSGU"] as [string, string],
+      position: [40.5023, -110.7456] as [number | null, number | null],
+    };
+    render(<SortieInfo onUpdate={jest.fn()} initialData={initialData} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /open in skyvector/i }));
+    expect(openSpy).toHaveBeenCalledWith(
+      "https://skyvector.com/?fpl=KPVU%20403008N1104444W%20KSGU",
+      "_blank",
+      "noopener,noreferrer"
+    );
+
+    openSpy.mockRestore();
+  });
+
+  it("falls back to two-waypoint URL when operating position has nulls", () => {
+    const openSpy = jest.spyOn(window, "open").mockImplementation(() => null);
+    const initialData = {
+      ...defaultInitialData,
+      airport: ["KPVU", "KSGU"] as [string, string],
+      position: [null, null] as [number | null, number | null],
+    };
+    render(<SortieInfo onUpdate={jest.fn()} initialData={initialData} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /open in skyvector/i }));
+    expect(openSpy).toHaveBeenCalledWith(
+      "https://skyvector.com/?fpl=KPVU%20KSGU",
+      "_blank",
+      "noopener,noreferrer"
+    );
+
+    openSpy.mockRestore();
+  });
 });
 
 describe("SortieInfo - position field wiring", () => {

--- a/src/components/SortieInfo.test.tsx
+++ b/src/components/SortieInfo.test.tsx
@@ -202,6 +202,32 @@ describe("SortieInfo - sortie timing relative display", () => {
   });
 });
 
+describe("SortieInfo — SkyVector button", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the button disabled when both airports are blank", () => {
+    render(<SortieInfo onUpdate={jest.fn()} initialData={defaultInitialData} />);
+    const button = screen.getByRole("button", { name: /open in skyvector/i });
+    expect(button).toBeDisabled();
+  });
+
+  it("renders the button disabled when only departure is set", () => {
+    const initialData = { ...defaultInitialData, airport: ["KPVU", ""] as [string, string] };
+    render(<SortieInfo onUpdate={jest.fn()} initialData={initialData} />);
+    const button = screen.getByRole("button", { name: /open in skyvector/i });
+    expect(button).toBeDisabled();
+  });
+
+  it("renders the button disabled when only arrival is set", () => {
+    const initialData = { ...defaultInitialData, airport: ["", "KSGU"] as [string, string] };
+    render(<SortieInfo onUpdate={jest.fn()} initialData={initialData} />);
+    const button = screen.getByRole("button", { name: /open in skyvector/i });
+    expect(button).toBeDisabled();
+  });
+});
+
 describe("SortieInfo - position field wiring", () => {
   it("calls onUpdate with both route and position when valid coords are entered", async () => {
     jest.useFakeTimers();

--- a/src/components/SortieInfo.tsx
+++ b/src/components/SortieInfo.tsx
@@ -424,7 +424,7 @@ export default function SortieInfo({ initialData, onUpdate }: SortieInfoProps) {
           const skyvectorUrl = buildSkyvectorUrl({
             departure: formData.airport?.[0] ?? "",
             arrival: formData.airport?.[1] ?? "",
-            operating: formData.position ?? null,
+            operating: formData.position,
           });
           const disabled = skyvectorUrl === null;
           return (

--- a/src/components/SortieInfo.tsx
+++ b/src/components/SortieInfo.tsx
@@ -4,6 +4,7 @@ import { ChangeEvent, useCallback, useEffect, useMemo, useState } from "react";
 import aircraftData from "@/data/aircraft.json";
 import type { WorksheetData } from "@/utils/types";
 import PositionInput from "@/components/PositionInput";
+import { buildSkyvectorUrl } from "@/utils/skyvector";
 
 interface SortieInfoProps {
   initialData?: WorksheetData;
@@ -419,6 +420,31 @@ export default function SortieInfo({ initialData, onUpdate }: SortieInfoProps) {
             />
           </div>
         </div>
+        {(() => {
+          const skyvectorUrl = buildSkyvectorUrl({
+            departure: formData.airport?.[0] ?? "",
+            arrival: formData.airport?.[1] ?? "",
+            operating: formData.position ?? null,
+          });
+          const disabled = skyvectorUrl === null;
+          return (
+            <div className="mt-4">
+              <button
+                type="button"
+                disabled={disabled}
+                onClick={() => {
+                  if (skyvectorUrl) {
+                    window.open(skyvectorUrl, "_blank", "noopener,noreferrer");
+                  }
+                }}
+                title={disabled ? "Set departure and arrival airports" : "Open route in SkyVector"}
+                className="inline-flex items-center gap-1.5 rounded-md border border-slate-300 px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-800"
+              >
+                Open in SkyVector
+              </button>
+            </div>
+          );
+        })()}
       </div>
 
       <div>

--- a/src/utils/__tests__/skyvector.test.ts
+++ b/src/utils/__tests__/skyvector.test.ts
@@ -8,4 +8,28 @@ describe("latLonToDmsWaypoint", () => {
   it("formats negative lat / positive lon", () => {
     expect(latLonToDmsWaypoint(-33.8688, 151.2093)).toBe("335208S1511233E");
   });
+
+  it("formats exact integer degrees", () => {
+    expect(latLonToDmsWaypoint(40, -110)).toBe("400000N1100000W");
+  });
+
+  it("formats zero coordinates with N/E suffix and correct widths", () => {
+    expect(latLonToDmsWaypoint(0, 0)).toBe("000000N0000000E");
+  });
+
+  it("treats negative zero as positive (N/E)", () => {
+    expect(latLonToDmsWaypoint(-0, -0)).toBe("000000N0000000E");
+  });
+
+  it("rolls seconds 60 over into minutes", () => {
+    // 40 + 59.9/60 + 59.6/3600 deg places seconds at ~59.6, which rounds to 60
+    // and should carry into minutes.
+    const lat = 40 + 59 / 60 + 59.6 / 3600;
+    expect(latLonToDmsWaypoint(lat, 0)).toBe("410000N0000000E");
+  });
+
+  it("clamps poles and anti-meridian", () => {
+    expect(latLonToDmsWaypoint(89.9999, 179.9999)).toBe("900000N1800000E");
+    expect(latLonToDmsWaypoint(-89.9999, -179.9999)).toBe("900000S1800000W");
+  });
 });

--- a/src/utils/__tests__/skyvector.test.ts
+++ b/src/utils/__tests__/skyvector.test.ts
@@ -1,4 +1,4 @@
-import { latLonToDmsWaypoint } from "@/utils/skyvector";
+import { buildSkyvectorUrl, latLonToDmsWaypoint } from "@/utils/skyvector";
 
 describe("latLonToDmsWaypoint", () => {
   it("formats positive lat / negative lon", () => {
@@ -34,5 +34,19 @@ describe("latLonToDmsWaypoint", () => {
     // Inputs strictly above ±90 / ±180 should hit the explicit clamp branch.
     expect(latLonToDmsWaypoint(91, 181)).toBe("900000N1800000E");
     expect(latLonToDmsWaypoint(-91, -181)).toBe("900000S1800000W");
+  });
+});
+
+describe("buildSkyvectorUrl", () => {
+  it("builds a three-waypoint URL when all fields are set", () => {
+    expect(
+      buildSkyvectorUrl({
+        departure: "KPVU",
+        arrival: "KSGU",
+        operating: [40.5023, -110.7456],
+      })
+    ).toBe(
+      "https://skyvector.com/?fpl=KPVU%20403008N1104444W%20KSGU"
+    );
   });
 });

--- a/src/utils/__tests__/skyvector.test.ts
+++ b/src/utils/__tests__/skyvector.test.ts
@@ -49,4 +49,42 @@ describe("buildSkyvectorUrl", () => {
       "https://skyvector.com/?fpl=KPVU%20403008N1104444W%20KSGU"
     );
   });
+
+  it("omits operating waypoint when operating is null", () => {
+    expect(
+      buildSkyvectorUrl({ departure: "KPVU", arrival: "KSGU", operating: null })
+    ).toBe("https://skyvector.com/?fpl=KPVU%20KSGU");
+  });
+
+  it("omits operating waypoint when one coordinate is null", () => {
+    expect(
+      buildSkyvectorUrl({
+        departure: "KPVU",
+        arrival: "KSGU",
+        operating: [40.5, null],
+      })
+    ).toBe("https://skyvector.com/?fpl=KPVU%20KSGU");
+  });
+
+  it("returns null when departure is empty", () => {
+    expect(
+      buildSkyvectorUrl({ departure: "", arrival: "KSGU", operating: null })
+    ).toBeNull();
+  });
+
+  it("returns null when arrival is whitespace-only", () => {
+    expect(
+      buildSkyvectorUrl({ departure: "KPVU", arrival: "   ", operating: null })
+    ).toBeNull();
+  });
+
+  it("uppercases and trims airport identifiers", () => {
+    expect(
+      buildSkyvectorUrl({
+        departure: " kpvu ",
+        arrival: "kSgU",
+        operating: null,
+      })
+    ).toBe("https://skyvector.com/?fpl=KPVU%20KSGU");
+  });
 });

--- a/src/utils/__tests__/skyvector.test.ts
+++ b/src/utils/__tests__/skyvector.test.ts
@@ -87,4 +87,14 @@ describe("buildSkyvectorUrl", () => {
       })
     ).toBe("https://skyvector.com/?fpl=KPVU%20KSGU");
   });
+
+  it("treats exact-zero operating coordinates as valid", () => {
+    expect(
+      buildSkyvectorUrl({
+        departure: "KPVU",
+        arrival: "KSGU",
+        operating: [0, 0],
+      })
+    ).toBe("https://skyvector.com/?fpl=KPVU%20000000N0000000E%20KSGU");
+  });
 });

--- a/src/utils/__tests__/skyvector.test.ts
+++ b/src/utils/__tests__/skyvector.test.ts
@@ -22,8 +22,8 @@ describe("latLonToDmsWaypoint", () => {
   });
 
   it("rolls seconds 60 over into minutes", () => {
-    // 40 + 59.9/60 + 59.6/3600 deg places seconds at ~59.6, which rounds to 60
-    // and should carry into minutes.
+    // minutes total ≈ 59.993, leaving seconds ≈ 59.6, which rounds to 60
+    // (carries into minutes, then minutes 60 carries into degrees).
     const lat = 40 + 59 / 60 + 59.6 / 3600;
     expect(latLonToDmsWaypoint(lat, 0)).toBe("410000N0000000E");
   });
@@ -31,5 +31,8 @@ describe("latLonToDmsWaypoint", () => {
   it("clamps poles and anti-meridian", () => {
     expect(latLonToDmsWaypoint(89.9999, 179.9999)).toBe("900000N1800000E");
     expect(latLonToDmsWaypoint(-89.9999, -179.9999)).toBe("900000S1800000W");
+    // Inputs strictly above ±90 / ±180 should hit the explicit clamp branch.
+    expect(latLonToDmsWaypoint(91, 181)).toBe("900000N1800000E");
+    expect(latLonToDmsWaypoint(-91, -181)).toBe("900000S1800000W");
   });
 });

--- a/src/utils/__tests__/skyvector.test.ts
+++ b/src/utils/__tests__/skyvector.test.ts
@@ -50,9 +50,13 @@ describe("buildSkyvectorUrl", () => {
     );
   });
 
-  it("omits operating waypoint when operating is null", () => {
+  it("omits operating waypoint when operating tuple has both nulls", () => {
     expect(
-      buildSkyvectorUrl({ departure: "KPVU", arrival: "KSGU", operating: null })
+      buildSkyvectorUrl({
+        departure: "KPVU",
+        arrival: "KSGU",
+        operating: [null, null],
+      })
     ).toBe("https://skyvector.com/?fpl=KPVU%20KSGU");
   });
 
@@ -68,13 +72,13 @@ describe("buildSkyvectorUrl", () => {
 
   it("returns null when departure is empty", () => {
     expect(
-      buildSkyvectorUrl({ departure: "", arrival: "KSGU", operating: null })
+      buildSkyvectorUrl({ departure: "", arrival: "KSGU", operating: [null, null] })
     ).toBeNull();
   });
 
   it("returns null when arrival is whitespace-only", () => {
     expect(
-      buildSkyvectorUrl({ departure: "KPVU", arrival: "   ", operating: null })
+      buildSkyvectorUrl({ departure: "KPVU", arrival: "   ", operating: [null, null] })
     ).toBeNull();
   });
 
@@ -83,7 +87,7 @@ describe("buildSkyvectorUrl", () => {
       buildSkyvectorUrl({
         departure: " kpvu ",
         arrival: "kSgU",
-        operating: null,
+        operating: [null, null],
       })
     ).toBe("https://skyvector.com/?fpl=KPVU%20KSGU");
   });

--- a/src/utils/__tests__/skyvector.test.ts
+++ b/src/utils/__tests__/skyvector.test.ts
@@ -1,0 +1,11 @@
+import { latLonToDmsWaypoint } from "@/utils/skyvector";
+
+describe("latLonToDmsWaypoint", () => {
+  it("formats positive lat / negative lon", () => {
+    expect(latLonToDmsWaypoint(40.5023, -110.7456)).toBe("403008N1104444W");
+  });
+
+  it("formats negative lat / positive lon", () => {
+    expect(latLonToDmsWaypoint(-33.8688, 151.2093)).toBe("335208S1511233E");
+  });
+});

--- a/src/utils/__tests__/skyvector.test.ts
+++ b/src/utils/__tests__/skyvector.test.ts
@@ -101,4 +101,15 @@ describe("buildSkyvectorUrl", () => {
       })
     ).toBe("https://skyvector.com/?fpl=KPVU%20000000N0000000E%20KSGU");
   });
+
+  it("encodes special characters in airport identifiers so they cannot inject query params", () => {
+    // Free-text inputs containing `&`, `#`, `%`, etc. must not break out of the fpl value.
+    expect(
+      buildSkyvectorUrl({
+        departure: "KPVU&foo=bar",
+        arrival: "KSGU#frag",
+        operating: [null, null],
+      })
+    ).toBe("https://skyvector.com/?fpl=KPVU%26FOO%3DBAR%20KSGU%23FRAG");
+  });
 });

--- a/src/utils/skyvector.ts
+++ b/src/utils/skyvector.ts
@@ -57,5 +57,5 @@ export function buildSkyvectorUrl(input: BuildSkyvectorUrlInput): string | null 
   }
   waypoints.push(arr);
 
-  return `https://skyvector.com/?fpl=${waypoints.join("%20")}`;
+  return `https://skyvector.com/?fpl=${waypoints.map(encodeURIComponent).join("%20")}`;
 }

--- a/src/utils/skyvector.ts
+++ b/src/utils/skyvector.ts
@@ -1,0 +1,42 @@
+const pad = (n: number, width: number): string =>
+  String(n).padStart(width, "0");
+
+export function latLonToDmsWaypoint(lat: number, lon: number): string {
+  const formatComponent = (
+    value: number,
+    degreeWidth: number,
+    maxDeg: number
+  ): { deg: number; min: number; sec: number } => {
+    const abs = Math.abs(value);
+    let deg = Math.floor(abs);
+    const minTotal = (abs - deg) * 60;
+    let min = Math.floor(minTotal);
+    let sec = Math.round((minTotal - min) * 60);
+    if (sec === 60) {
+      sec = 0;
+      min += 1;
+    }
+    if (min === 60) {
+      min = 0;
+      deg += 1;
+    }
+    if (deg > maxDeg) deg = maxDeg;
+    return { deg, min, sec };
+  };
+
+  const latParts = formatComponent(lat, 2, 90);
+  const lonParts = formatComponent(lon, 3, 180);
+  const latSuffix = lat < 0 ? "S" : "N";
+  const lonSuffix = lon < 0 ? "W" : "E";
+
+  return (
+    pad(latParts.deg, 2) +
+    pad(latParts.min, 2) +
+    pad(latParts.sec, 2) +
+    latSuffix +
+    pad(lonParts.deg, 3) +
+    pad(lonParts.min, 2) +
+    pad(lonParts.sec, 2) +
+    lonSuffix
+  );
+}

--- a/src/utils/skyvector.ts
+++ b/src/utils/skyvector.ts
@@ -39,3 +39,27 @@ export function latLonToDmsWaypoint(lat: number, lon: number): string {
     lonSuffix
   );
 }
+
+export interface BuildSkyvectorUrlInput {
+  departure: string;
+  arrival: string;
+  operating: [number | null, number | null] | null;
+}
+
+export function buildSkyvectorUrl(input: BuildSkyvectorUrlInput): string | null {
+  const dep = input.departure.trim().toUpperCase();
+  const arr = input.arrival.trim().toUpperCase();
+  if (!dep || !arr) return null;
+
+  const waypoints: string[] = [dep];
+  if (
+    input.operating &&
+    input.operating[0] !== null &&
+    input.operating[1] !== null
+  ) {
+    waypoints.push(latLonToDmsWaypoint(input.operating[0], input.operating[1]));
+  }
+  waypoints.push(arr);
+
+  return `https://skyvector.com/?fpl=${waypoints.join("%20")}`;
+}

--- a/src/utils/skyvector.ts
+++ b/src/utils/skyvector.ts
@@ -4,7 +4,6 @@ const pad = (n: number, width: number): string =>
 export function latLonToDmsWaypoint(lat: number, lon: number): string {
   const formatComponent = (
     value: number,
-    degreeWidth: number,
     maxDeg: number
   ): { deg: number; min: number; sec: number } => {
     const abs = Math.abs(value);
@@ -24,8 +23,8 @@ export function latLonToDmsWaypoint(lat: number, lon: number): string {
     return { deg, min, sec };
   };
 
-  const latParts = formatComponent(lat, 2, 90);
-  const lonParts = formatComponent(lon, 3, 180);
+  const latParts = formatComponent(lat, 90);
+  const lonParts = formatComponent(lon, 180);
   const latSuffix = lat < 0 ? "S" : "N";
   const lonSuffix = lon < 0 ? "W" : "E";
 

--- a/src/utils/skyvector.ts
+++ b/src/utils/skyvector.ts
@@ -43,7 +43,7 @@ export function latLonToDmsWaypoint(lat: number, lon: number): string {
 export interface BuildSkyvectorUrlInput {
   departure: string;
   arrival: string;
-  operating: [number | null, number | null] | null;
+  operating: [number | null, number | null];
 }
 
 export function buildSkyvectorUrl(input: BuildSkyvectorUrlInput): string | null {
@@ -52,11 +52,7 @@ export function buildSkyvectorUrl(input: BuildSkyvectorUrlInput): string | null 
   if (!dep || !arr) return null;
 
   const waypoints: string[] = [dep];
-  if (
-    input.operating &&
-    input.operating[0] !== null &&
-    input.operating[1] !== null
-  ) {
+  if (input.operating[0] !== null && input.operating[1] !== null) {
     waypoints.push(latLonToDmsWaypoint(input.operating[0], input.operating[1]));
   }
   waypoints.push(arr);


### PR DESCRIPTION
## Summary

- New "Open in SkyVector" button in the Sortie Info **Where** section opens the planned route (departure → operating area → arrival) on skyvector.com in a new tab.
- Operating waypoint is encoded as an ICAO-style DMS coordinate (`DDMMSS[NS]DDDMMSS[EW]`) when `position` is parsed; falls back to a two-waypoint Dep→Arr URL otherwise.
- Button is disabled (with tooltip) until both departure and arrival airports are set.

Closes #101.

## Design & Plan

- Spec: `docs/superpowers/specs/2026-05-17-skyvector-button-design.md`
- Plan: `docs/superpowers/plans/2026-05-17-skyvector-button.md`

## Test plan

- [x] `npm test` — 41 suites, 564 tests, all pass (14 new unit tests for `latLonToDmsWaypoint` / `buildSkyvectorUrl`, 6 new component tests for the button).
- [x] `npm run lint` — clean.
- [x] `npm run build` — succeeds.
- [ ] Manual smoke: in dev, enter `KPVU` / `KSGU`, click "Open in SkyVector" → new tab opens to the right route.
- [ ] Manual smoke: enter a parseable operating position (e.g., `FFU180020`), confirm the three-waypoint route shows up in SkyVector.
- [ ] Manual smoke: clear arrival airport → button becomes disabled with tooltip "Set departure and arrival airports".

## Possible follow-ups (not blocking)

- Consider switching `window.open` → `<a target="_blank" rel="noopener noreferrer">` to match other external links (`WeatherSection.tsx`, `InstructionsPanel.tsx`). The spec deliberately chose `window.open` so the disabled state can be a real `<button disabled>`; revisit if accessibility (middle-click, cmd-click, screen readers) becomes a concern.
- `title` is the only disabled-reason hint today; consider an `aria-describedby` or inline helper text for screen-reader / keyboard users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)