### PR TITLE
Fix 35 latent TypeScript errors surfaced by Next 16.3.0

### DIFF
--- a/src/components/AppInputs.test.tsx
+++ b/src/components/AppInputs.test.tsx
@@ -104,7 +104,7 @@ describe("AppInputs", () => {
   });
 
   it("renders WeatherSection with non-default state", () => {
-    const testState = {
+    const testState: WorksheetData = {
       ...defaultState,
       wind: [
         [0, 260, 270, 340, 345],
@@ -195,7 +195,7 @@ describe("AppInputs", () => {
   });
 
   it("renders with different initial states", () => {
-    const populatedState = {
+    const populatedState: WorksheetData = {
       ...defaultState,
       pilot: "John Doe",
       date: "2025-01-24",

--- a/src/components/Calculations.tsx
+++ b/src/components/Calculations.tsx
@@ -68,7 +68,7 @@ export default function Calculations({ state }: CalculationsProps) {
         </TOLDErrorBoundary>
         <ManeuveringPerformance
           aircraftModel={state.acType}
-          maneuveringSpeeds={maneuveringSpeeds ?? undefined}
+          maneuveringSpeeds={maneuveringSpeeds}
         />
       </div>
     </div>

--- a/src/components/ManeuveringPerformance.tsx
+++ b/src/components/ManeuveringPerformance.tsx
@@ -2,7 +2,7 @@ import type { ManeuveringSpeeds } from "@/utils/types";
 
 interface ManeuveringPerformanceProps {
   aircraftModel?: string;
-  maneuveringSpeeds?: ManeuveringSpeeds;
+  maneuveringSpeeds?: ManeuveringSpeeds | null;
 }
 
 export default function ManeuveringPerformance({

--- a/src/components/WeatherDataIntegration.test.tsx
+++ b/src/components/WeatherDataIntegration.test.tsx
@@ -43,6 +43,7 @@ describe("WeatherDataIntegration", () => {
       temperature: false,
       pressure: false,
       runway: false,
+      altitude: false,
     });
   });
 
@@ -60,6 +61,7 @@ describe("WeatherDataIntegration", () => {
       temperature: false,
       pressure: false,
       runway: false,
+      altitude: false,
     });
 
     render(<WeatherDataIntegration {...defaultProps} />);

--- a/src/utils/__tests__/formulas.test.ts
+++ b/src/utils/__tests__/formulas.test.ts
@@ -200,19 +200,21 @@ describe("Vra Calculation Function", () => {
   });
 
   test("returns null for aircraft with missing stallSpeeds", () => {
+    // Deliberately malformed: calculateVra must defend against bad data
     const aircraftWithoutStallSpeeds = {
       ...mockAircraft,
       stallSpeeds: undefined,
-    } as Aircraft;
+    } as unknown as Aircraft;
     const result = calculateVra(aircraftWithoutStallSpeeds);
     expect(result).toBeNull();
   });
 
   test("returns null for aircraft with missing Vso array", () => {
+    // Deliberately malformed: calculateVra must defend against bad data
     const aircraftWithoutVso = {
       ...mockAircraft,
       stallSpeeds: { flaps: [0, 30], Vso: undefined },
-    } as Aircraft;
+    } as unknown as Aircraft;
     const result = calculateVra(aircraftWithoutVso);
     expect(result).toBeNull();
   });

--- a/src/utils/__tests__/toldCalculations.test.ts
+++ b/src/utils/__tests__/toldCalculations.test.ts
@@ -10,8 +10,8 @@ import {
   validateTemperature,
   validateRunwayLength,
   validateTOLDInputs,
-  type TOLDCalculationParams,
 } from "../toldCalculations";
+import type { TOLDCalculationParams } from "@/utils/types";
 
 const mockLog = jest.spyOn(console, "log").mockImplementation(() => {});
 const mockWarn = jest.spyOn(console, "warn").mockImplementation(() => {});
@@ -510,8 +510,8 @@ describe("TOLD Calculations", () => {
     it("should return results when temperature is 0°C", () => {
       const result = calculateTOLDForMultipleAirports("C182T", {
         weight: 2800,
-        pressureAltitudes: [1000, 1000, 1000],
-        temperatures: [0, 0, 0], // 0°C — falsy but valid
+        pressureAltitudes: [1000, 1000],
+        temperatures: [0, 0], // 0°C — falsy but valid
         runwayLengths: [3000, 3000],
       });
       expect(result.success).toBe(true);
@@ -522,8 +522,8 @@ describe("TOLD Calculations", () => {
     it("should return results when pressure altitude is 0 ft (sea level)", () => {
       const result = calculateTOLDForMultipleAirports("C182T", {
         weight: 2800,
-        pressureAltitudes: [0, 0, 0], // 0 ft — valid sea-level PA
-        temperatures: [20, 20, 20],
+        pressureAltitudes: [0, 0], // 0 ft — valid sea-level PA
+        temperatures: [20, 20],
         runwayLengths: [3000, 3000],
       });
       expect(result.success).toBe(true);
@@ -534,8 +534,8 @@ describe("TOLD Calculations", () => {
     it("should return results when both temperature is 0°C and pressure altitude is 0 ft", () => {
       const result = calculateTOLDForMultipleAirports("C182T", {
         weight: 2800,
-        pressureAltitudes: [0, 0, 0],
-        temperatures: [0, 0, 0],
+        pressureAltitudes: [0, 0],
+        temperatures: [0, 0],
         runwayLengths: [3000, 3000],
       });
       expect(result.success).toBe(true);
@@ -547,8 +547,8 @@ describe("TOLD Calculations", () => {
       // Regression test for || null vs ?? null bug in result combining
       const result = calculateTOLDForMultipleAirports("C182T", {
         weight: 2800,
-        pressureAltitudes: [0, 0, 0],
-        temperatures: [0, 0, 0],
+        pressureAltitudes: [0, 0],
+        temperatures: [0, 0],
         runwayLengths: [3000, 3000],
       });
       // All result fields should be defined (not null from || coercion)

--- a/src/utils/aviationWeatherApi.ts
+++ b/src/utils/aviationWeatherApi.ts
@@ -288,7 +288,8 @@ async function makeApiRequest<T>(
  */
 export async function getMETAR(
   airports: string[],
-  hoursBeforeNow: number = 1
+  hoursBeforeNow: number = 1,
+  retries: number = 3
 ): Promise<METARResponse[]> {
   const params = {
     ids: airports.join(","),
@@ -296,7 +297,7 @@ export async function getMETAR(
     hours: hoursBeforeNow.toString(),
   };
 
-  return makeApiRequest<METARResponse[]>("metar", params);
+  return makeApiRequest<METARResponse[]>("metar", params, retries);
 }
 
 /**
@@ -304,7 +305,8 @@ export async function getMETAR(
  */
 export async function getTAF(
   airports: string[],
-  hoursBeforeNow: number = 24
+  hoursBeforeNow: number = 24,
+  retries: number = 3
 ): Promise<TAFResponse[]> {
   const params = {
     ids: airports.join(","),
@@ -312,7 +314,7 @@ export async function getTAF(
     hours: hoursBeforeNow.toString(),
   };
 
-  return makeApiRequest<TAFResponse[]>("taf", params);
+  return makeApiRequest<TAFResponse[]>("taf", params, retries);
 }
 
 /**

--- a/src/utils/toldCalculations.ts
+++ b/src/utils/toldCalculations.ts
@@ -608,7 +608,7 @@ function findWeightIndex(weights: number[], targetWeight: number): number {
  * @returns Validation result with errors and warnings
  */
 export function validateAircraftWeight(
-  weight: number | null,
+  weight: number | null | undefined,
   aircraftModel: string
 ): TOLDValidationResult {
   const errors: TOLDError[] = [];
@@ -680,7 +680,7 @@ export function validateAircraftWeight(
  * @returns Validation result with errors and warnings
  */
 export function validatePressureAltitude(
-  pressureAltitude: number | null
+  pressureAltitude: number | null | undefined
 ): TOLDValidationResult {
   const errors: TOLDError[] = [];
   const warnings: TOLDError[] = [];
@@ -726,7 +726,7 @@ export function validatePressureAltitude(
  * @returns Validation result with errors and warnings
  */
 export function validateTemperature(
-  temperature: number | null
+  temperature: number | null | undefined
 ): TOLDValidationResult {
   const errors: TOLDError[] = [];
   const warnings: TOLDError[] = [];
@@ -778,7 +778,7 @@ export function validateTemperature(
  * @returns Validation result with errors and warnings
  */
 export function validateRunwayLength(
-  runwayLength: number | null
+  runwayLength: number | null | undefined
 ): TOLDValidationResult {
   const errors: TOLDError[] = [];
   const warnings: TOLDError[] = [];

--- a/src/utils/toldCalculations.ts
+++ b/src/utils/toldCalculations.ts
@@ -603,7 +603,7 @@ function findWeightIndex(weights: number[], targetWeight: number): number {
 
 /**
  * Validate aircraft weight against aircraft specifications
- * @param weight The aircraft weight in pounds (can be null)
+ * @param weight The aircraft weight in pounds (can be null or undefined)
  * @param aircraftModel The aircraft model identifier
  * @returns Validation result with errors and warnings
  */
@@ -676,7 +676,7 @@ export function validateAircraftWeight(
 
 /**
  * Validate pressure altitude against typical operating ranges
- * @param pressureAltitude The pressure altitude in feet (can be null)
+ * @param pressureAltitude The pressure altitude in feet (can be null or undefined)
  * @returns Validation result with errors and warnings
  */
 export function validatePressureAltitude(
@@ -722,7 +722,7 @@ export function validatePressureAltitude(
 
 /**
  * Validate temperature against typical operating ranges
- * @param temperature The temperature in Celsius (can be null)
+ * @param temperature The temperature in Celsius (can be null or undefined)
  * @returns Validation result with errors and warnings
  */
 export function validateTemperature(
@@ -774,7 +774,7 @@ export function validateTemperature(
 
 /**
  * Validate runway length against typical requirements
- * @param runwayLength The runway length in feet (can be null)
+ * @param runwayLength The runway length in feet (can be null or undefined)
  * @returns Validation result with errors and warnings
  */
 export function validateRunwayLength(

--- a/src/utils/weatherDataMapper.test.ts
+++ b/src/utils/weatherDataMapper.test.ts
@@ -562,7 +562,7 @@ describe("Weather Data Mapper", () => {
 
   describe("isApiPopulatedData", () => {
     it("should detect API-populated wind data", () => {
-      const data : Partial<WorksheetData> = {
+      const data: Partial<WorksheetData> = {
         wind: [
           [270, 0, 0, 0, 0],
           [25, 0, 0, 0, 0],
@@ -579,7 +579,7 @@ describe("Weather Data Mapper", () => {
     });
 
     it("should detect API-populated temperature data", () => {
-      const data : Partial<WorksheetData> = {
+      const data: Partial<WorksheetData> = {
         temp: [18, 18, 18], // Different from default 21
       };
 
@@ -592,7 +592,7 @@ describe("Weather Data Mapper", () => {
     });
 
     it("should detect API-populated pressure data", () => {
-      const data : Partial<WorksheetData> = {
+      const data: Partial<WorksheetData> = {
         altimeter: [29.85, 29.85, 29.85], // Different from default 29.92
       };
 
@@ -605,7 +605,7 @@ describe("Weather Data Mapper", () => {
     });
 
     it("should detect API-populated runway data", () => {
-      const data : Partial<WorksheetData> = {
+      const data: Partial<WorksheetData> = {
         rwy: [10000, null],
       };
 
@@ -618,7 +618,7 @@ describe("Weather Data Mapper", () => {
     });
 
     it("should detect null values as not API-populated", () => {
-      const data : Partial<WorksheetData> = {
+      const data: Partial<WorksheetData> = {
         wind: [
           [null, null, null, null, null],
           [null, null, null, null, null],
@@ -640,7 +640,7 @@ describe("Weather Data Mapper", () => {
 
   describe("mergeWeatherData", () => {
     it("should merge API data with existing data", () => {
-      const existingData : Partial<WorksheetData> = {
+      const existingData: Partial<WorksheetData> = {
         wind: [
           [0, 0, 0, 0, 0],
           [0, 0, 0, 0, 0],
@@ -651,7 +651,7 @@ describe("Weather Data Mapper", () => {
         rwy: [null, null],
       };
 
-      const apiData : Partial<WorksheetData> = {
+      const apiData: Partial<WorksheetData> = {
         wind: [
           [270, 0, 0, 0, 0],
           [25, 0, 0, 0, 0],
@@ -671,7 +671,7 @@ describe("Weather Data Mapper", () => {
     });
 
     it("should preserve user-modified data when preserveUserData is true", () => {
-      const existingData : Partial<WorksheetData> = {
+      const existingData: Partial<WorksheetData> = {
         wind: [
           [180, 0, 0, 0, 0],
           [20, 0, 0, 0, 0],
@@ -682,7 +682,7 @@ describe("Weather Data Mapper", () => {
         rwy: [5000, null], // User modified
       };
 
-      const apiData : Partial<WorksheetData> = {
+      const apiData: Partial<WorksheetData> = {
         wind: [
           [270, 0, 0, 0, 0],
           [25, 0, 0, 0, 0],
@@ -724,7 +724,7 @@ describe("Weather Data Mapper", () => {
     });
 
     it("should overwrite user data when preserveUserData is false", () => {
-      const existingData : Partial<WorksheetData> = {
+      const existingData: Partial<WorksheetData> = {
         wind: [
           [180, 0, 0, 0, 0],
           [20, 0, 0, 0, 0],
@@ -735,7 +735,7 @@ describe("Weather Data Mapper", () => {
         rwy: [5000, null],
       };
 
-      const apiData : Partial<WorksheetData> = {
+      const apiData: Partial<WorksheetData> = {
         wind: [
           [270, 0, 0, 0, 0],
           [25, 0, 0, 0, 0],

--- a/src/utils/weatherDataMapper.test.ts
+++ b/src/utils/weatherDataMapper.test.ts
@@ -17,6 +17,7 @@ import type {
   TAFResponse,
   AirportResponse,
 } from "./aviationWeatherApi";
+import type { WorksheetData } from "@/utils/types";
 
 describe("Weather Data Mapper", () => {
   describe("mapRunwayData", () => {
@@ -561,7 +562,7 @@ describe("Weather Data Mapper", () => {
 
   describe("isApiPopulatedData", () => {
     it("should detect API-populated wind data", () => {
-      const data = {
+      const data : Partial<WorksheetData> = {
         wind: [
           [270, 0, 0, 0, 0],
           [25, 0, 0, 0, 0],
@@ -578,7 +579,7 @@ describe("Weather Data Mapper", () => {
     });
 
     it("should detect API-populated temperature data", () => {
-      const data = {
+      const data : Partial<WorksheetData> = {
         temp: [18, 18, 18], // Different from default 21
       };
 
@@ -591,7 +592,7 @@ describe("Weather Data Mapper", () => {
     });
 
     it("should detect API-populated pressure data", () => {
-      const data = {
+      const data : Partial<WorksheetData> = {
         altimeter: [29.85, 29.85, 29.85], // Different from default 29.92
       };
 
@@ -604,7 +605,7 @@ describe("Weather Data Mapper", () => {
     });
 
     it("should detect API-populated runway data", () => {
-      const data = {
+      const data : Partial<WorksheetData> = {
         rwy: [10000, null],
       };
 
@@ -617,7 +618,7 @@ describe("Weather Data Mapper", () => {
     });
 
     it("should detect null values as not API-populated", () => {
-      const data = {
+      const data : Partial<WorksheetData> = {
         wind: [
           [null, null, null, null, null],
           [null, null, null, null, null],
@@ -639,7 +640,7 @@ describe("Weather Data Mapper", () => {
 
   describe("mergeWeatherData", () => {
     it("should merge API data with existing data", () => {
-      const existingData = {
+      const existingData : Partial<WorksheetData> = {
         wind: [
           [0, 0, 0, 0, 0],
           [0, 0, 0, 0, 0],
@@ -650,7 +651,7 @@ describe("Weather Data Mapper", () => {
         rwy: [null, null],
       };
 
-      const apiData = {
+      const apiData : Partial<WorksheetData> = {
         wind: [
           [270, 0, 0, 0, 0],
           [25, 0, 0, 0, 0],
@@ -670,7 +671,7 @@ describe("Weather Data Mapper", () => {
     });
 
     it("should preserve user-modified data when preserveUserData is true", () => {
-      const existingData = {
+      const existingData : Partial<WorksheetData> = {
         wind: [
           [180, 0, 0, 0, 0],
           [20, 0, 0, 0, 0],
@@ -681,7 +682,7 @@ describe("Weather Data Mapper", () => {
         rwy: [5000, null], // User modified
       };
 
-      const apiData = {
+      const apiData : Partial<WorksheetData> = {
         wind: [
           [270, 0, 0, 0, 0],
           [25, 0, 0, 0, 0],
@@ -723,7 +724,7 @@ describe("Weather Data Mapper", () => {
     });
 
     it("should overwrite user data when preserveUserData is false", () => {
-      const existingData = {
+      const existingData : Partial<WorksheetData> = {
         wind: [
           [180, 0, 0, 0, 0],
           [20, 0, 0, 0, 0],
@@ -734,7 +735,7 @@ describe("Weather Data Mapper", () => {
         rwy: [5000, null],
       };
 
-      const apiData = {
+      const apiData : Partial<WorksheetData> = {
         wind: [
           [270, 0, 0, 0, 0],
           [25, 0, 0, 0, 0],


### PR DESCRIPTION
Unblocks #162 (Next security bump).

## Why

`next build` on 16.2.10 doesn't type-check test files, hiding 35 real type errors that `tsc --noEmit` has been reporting on `main` all along. Next 16.3.0 widens the build's type check to cover them, so #162 fails CI — not because of anything in that bump, but because of this pre-existing breakage.

Verified: TypeScript is unchanged at 5.9.3 on both sides of #162; only `next` moves. `npx tsc --noEmit` on `main` reports the same 35 errors, while `npm run build` on `main` passes.

This matters beyond #162 — every future Next bump hits the same wall until it's fixed.

## Test-side fixes

- **`toldCalculations.test.ts`** — pass 2-element `[departure, arrival]` tuples to `calculateTOLDForMultipleAirports`. The function reads indices `[0]` and `[1]`, and the production caller in `derived.ts` already extracts departure/arrival out of the domain 3-tuple before calling. The tests were passing 3 elements. Also imports `TOLDCalculationParams` from `@/utils/types`, where it's actually exported.
- **`weatherDataMapper.test.ts`** — annotate fixtures as `Partial<WorksheetData>` so array literals get their contextual tuple types instead of widening to `number[]`.
- **`AppInputs.test.tsx`** — annotate fixtures as `WorksheetData`.
- **`WeatherDataIntegration.test.tsx`** — add the missing `altitude` key to `isApiPopulatedData` mock return values.
- **`formulas.test.ts`** — use `as unknown as Aircraft` for the deliberately malformed fixtures that exercise `calculateVra`'s guard clauses.

## Source fixes

Each closes a gap the tests were already exercising. No runtime behavior changes.

- **`toldCalculations.ts`** — the four validators explicitly check `=== undefined` at runtime but didn't declare it. Widened to `number | null | undefined`.
- **`aviationWeatherApi.ts`** — thread `retries` through `getMETAR`/`getTAF` to `makeApiRequest`. The tests already passed a third argument that was silently discarded. Defaults to `3`, so nothing changes for existing callers. (Note: this is not a test speedup — `APIError`s were never retried anyway.)
- **`ManeuveringPerformance.tsx`** — accept `ManeuveringSpeeds | null`, matching the component's own `if (!maneuveringSpeeds)` guard, and drop the `?? undefined` workaround at the `Calculations.tsx` call site.

## Verification

Ran against **both** dependency sets:

| | Next 16.2.10 (`main`) | Next 16.3.0 (#162) |
|---|---|---|
| `tsc --noEmit` | 0 errors | 0 errors |
| `npm run lint` | clean | clean |
| `npm test` | 601 passed / 43 suites | 601 passed / 43 suites |
| `npm run build` | pass | pass |

The 16.3.0 column was run in a clean worktree with #162's `package.json` + `package-lock.json` and a fresh `npm ci`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)