### PR TITLE
Ignore eslint 10.x in Dependabot until upstream supports it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,16 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    ignore:
+      # eslint 10 cannot be installed: eslint-config-next depends on
+      # eslint-plugin-react, whose peer range caps at `eslint ^9.7`.
+      # eslint-plugin-react has published nothing since 2025-04-03, so there is
+      # no timeline for a fix and npm ci fails with ERESOLVE on every attempt.
+      #
+      # Scoped to 10.x on purpose: eslint 9.x security updates still come
+      # through, and eslint 11 will still be proposed when it ships.
+      #
+      # Remove this once eslint-plugin-react supports eslint 10 and
+      # eslint-config-next depends on that version.
+      - dependency-name: "eslint"
+        versions: ["10.x"]


### PR DESCRIPTION
Closes the loop on #154, which can never pass CI in its current form.

## Why

ESLint 10 cannot be installed in this repo:

```
package.json          → eslint@10
eslint-config-next    → eslint-plugin-react@^7.37.0
eslint-plugin-react   → peer eslint: "^3 || … || ^9.7"   ← breaks here
```

`npm ci` fails with `ERESOLVE` on every attempt, so #154 has never had a passing build since it was opened on 2026-07-14.

There is no workaround available from our own manifest. Dropping the direct `eslint-plugin-react` devDependency changes nothing — `eslint-config-next` pulls the same constraint transitively.

And there's no timeline for a fix: **eslint-plugin-react has published no release since 2025-04-03**, ~16 months ago. The `next` dist-tag is `7.8.0-rc.0`, which is *older* than `latest` (7.8 < 7.37) and peers `eslint ^3 || ^4` — a stale mis-tag, not a path forward.

## Why this rule shape

Scoped to `versions: ["10.x"]` rather than `update-types: ["version-update:semver-major"]`, deliberately.

Dependabot ignore rules [apply to security updates as well as version updates](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file), and a `semver-major` rule is permanent and unscoped — it would suppress ESLint 11, 12, and every later major, plus any advisory whose fix landed in one. That's the kind of rule that rots silently.

Pinning to the known-uninstallable range behaves correctly on all three axes:

| | behavior |
|---|---|
| eslint **9.x** security advisories | still delivered (we're on 9, so this is the one that matters) |
| eslint **11** when it ships | still proposed; rule no longer applies |
| eslint **10.x** | suppressed — verified uninstallable |

It effectively self-expires. The only thing hidden is a version confirmed not to install.

The rule carries an inline comment stating the exact condition for removal: eslint-plugin-react supporting v10, and eslint-config-next depending on that version.

## Note on #153

Left alone deliberately. TypeScript 7 is blocked by `typescript-eslint` (peer `typescript >=4.8.4 <6.1.0`), but that project published as recently as 2026-08-13 and is actively maintained, so it should resolve upstream without intervention.

## Verification

YAML parses to the intended structure:

```json
{ "version": 2, "updates": [ { "package-ecosystem": "npm", "directory": "/",
  "schedule": { "interval": "weekly" },
  "ignore": [ { "dependency-name": "eslint", "versions": ["10.x"] } ] } ] }
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)