### PR TITLE
Flag grouped Dependabot updates instead of silently skipping them

### DIFF
--- a/.github/workflows/dependabot-review.yml
+++ b/.github/workflows/dependabot-review.yml
@@ -31,6 +31,33 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Grouped PRs report an empty update-type, because one group can span
+      # several semver levels. Every step in this job gates on update-type, so
+      # they all skip and both jobs pass while doing nothing -- the PR sits
+      # green and unmerged with no indication that it needs a human. Security
+      # updates are grouped by ecosystem automatically, so this silently
+      # affects exactly the PRs that matter most. Say it out loud instead.
+      #
+      # Skipped on synchronize so a Dependabot rebase doesn't re-comment.
+      - name: Flag grouped updates for manual merge
+        if: |
+          steps.metadata.outputs.dependency-group != '' &&
+          github.event.action != 'synchronize'
+        run: |
+          gh pr comment "$PR_URL" --body "**Grouped update — needs a manual merge.**
+
+          Dependabot reports an empty update-type for grouped PRs, since one group can span several semver levels. Auto-approve and auto-merge both gate on update-type, so both skip: this PR will stay green and unmerged until someone merges it by hand.
+
+          Group: $GROUP
+          Packages: $PACKAGES
+
+          A group can contain a major bump, which would normally be held back for review, so check the versions before merging."
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GROUP: ${{ steps.metadata.outputs.dependency-group }}
+          PACKAGES: ${{ steps.metadata.outputs.dependency-names }}
+
       - name: Flag major updates for manual review
         if: steps.metadata.outputs.update-type == 'version-update:semver-major'
         run: |


### PR DESCRIPTION
## The problem

All three steps in the `review` job gate on a single value:

```yaml
if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || ...
```

`dependabot/fetch-metadata` reports an **empty `update-type` for grouped PRs**, because one group can span several semver levels. So for a grouped PR:

| Step | Grouped PR |
|---|---|
| Auto-approve patch/minor | skipped |
| Flag major | skipped |
| Auto-merge patch/minor | skipped |

Every step no-ops and both jobs report **success having done nothing**. The PR sits green and unmerged with no signal that it needs a human.

Dependabot groups **security** updates by ecosystem automatically, so this silently affects exactly the PRs that matter most. #162 carried four high-severity Next advisories and sat green for ~7 hours before anyone noticed the automation hadn't run.

## The change

One new step keyed on `dependency-group`, which fetch-metadata sets to the group name (empty string otherwise) — the clean discriminator for this case. A grouped PR now gets an explicit comment saying it needs a manual merge, and why.

## What this deliberately does *not* do

It does **not** auto-merge grouped updates. That looks like the obvious two-line fix, and it's a trap: because `update-type` is empty for a group, there is no way to tell whether the group contains a **major** bump. Allowing group automerge would silently reintroduce the majors this workflow holds back for review on purpose.

Making groups safely auto-mergeable needs a `groups` config in `dependabot.yml` restricting them to `update-types: ["patch", "minor"]`, so majors can't be in a group by construction — worth doing only if manual merges become a burden, and worth verifying against auto-created security groups first.

## Details worth noting

- **Skipped on `synchronize`** so a Dependabot rebase doesn't re-comment. (We rebased three PRs today; without this each would have re-notified.)
- **Dynamic values pass through `env`** rather than inline `${{ }}` in the `run:` script, so package names can't be interpreted as shell. The pre-existing "Flag major" step interpolates `dependency-names` directly; worth tightening separately.
- **No backticks in the comment body**, avoiding command substitution inside the double-quoted string.

## Verification

Parsed the workflow and executed the rendered step against a stubbed `gh`:

```
ARG: [pr]  ARG: [comment]  ARG: [https://example/pr/1]  ARG: [--body]
ARG: [**Grouped update — needs a manual merge.**
      …
      Group: npm_and_yarn
      Packages: next, js-yaml, postcss
      …]
```

Body arrives as a single argument, variables interpolate correctly, and every line dedents to column 0 so nothing renders as an unintended code block.

## Not included: required status checks

The other half of the recommendation was making `test` a **required status check on `main`**. `main` is currently unprotected, so auto-merge's "merge after all *required* checks pass" contract has nothing to enforce — it currently waits for pending checks, but that's GitHub being conservative rather than a gate you configured.

I couldn't apply that here (repo-settings change blocked by my permissions). See the PR discussion for the exact command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)